### PR TITLE
Player and DM notes scrollbar fix.

### DIFF
--- a/DMScript.js
+++ b/DMScript.js
@@ -4113,8 +4113,26 @@ function addNewNote(groupContainer, noteData = null) {
 
     // Auto-resize description textarea
     noteDescription.addEventListener('input', function () {
-        noteDescription.style.height = 'auto';
-        noteDescription.style.height = `${noteDescription.scrollHeight}px`;
+        // Save all scroll positions
+        const currentScrollPos = noteDescription.scrollTop;
+        const currentHeight = noteDescription.offsetHeight;
+        const windowScrollY = window.scrollY || window.pageYOffset;
+        const windowScrollX = window.scrollX || window.pageXOffset;
+
+        // Temporarily set to a minimum height instead of 'auto'
+        noteDescription.style.height = '0px';
+        const newHeight = noteDescription.scrollHeight;
+
+        // Only update if height actually changed
+        if (newHeight !== currentHeight) {
+            noteDescription.style.height = `${newHeight}px`;
+        } else {
+            noteDescription.style.height = `${currentHeight}px`;
+        }
+
+        // Restore all scroll positions
+        noteDescription.scrollTop = currentScrollPos;
+        window.scrollTo(windowScrollX, windowScrollY);
     });
 
     //Saving everything when a note has been changed. 

--- a/PlayerScript.js
+++ b/PlayerScript.js
@@ -7201,8 +7201,26 @@ function addNewNote(groupContainer, noteData = null) {
 
     // Auto-resize description textarea
     noteDescription.addEventListener('input', function () {
-        noteDescription.style.height = 'auto';
-        noteDescription.style.height = `${noteDescription.scrollHeight}px`;
+        // Save all scroll positions
+        const currentScrollPos = noteDescription.scrollTop;
+        const currentHeight = noteDescription.offsetHeight;
+        const windowScrollY = window.scrollY || window.pageYOffset;
+        const windowScrollX = window.scrollX || window.pageXOffset;
+
+        // Temporarily set to a minimum height instead of 'auto'
+        noteDescription.style.height = '0px';
+        const newHeight = noteDescription.scrollHeight;
+
+        // Only update if height actually changed
+        if (newHeight !== currentHeight) {
+            noteDescription.style.height = `${newHeight}px`;
+        } else {
+            noteDescription.style.height = `${currentHeight}px`;
+        }
+
+        // Restore all scroll positions
+        noteDescription.scrollTop = currentScrollPos;
+        window.scrollTo(windowScrollX, windowScrollY);
     });
 
     //Saving everything when a note has been changed. 

--- a/SharedScript.js
+++ b/SharedScript.js
@@ -5842,12 +5842,36 @@ function setupMagicBonusSelection() {
 // Function to auto-resize textareas
 function autoResizeTextareas() {
     const textareas = document.querySelectorAll('.note-description');
+
+    // Save all scroll positions
+    const docsSection = document.getElementById('Docs');
+    const savedScrollTop = docsSection ? docsSection.scrollTop : 0;
+    const windowScrollY = window.scrollY || window.pageYOffset;
+    const windowScrollX = window.scrollX || window.pageXOffset;
+
     textareas.forEach((textarea) => {
-        setTimeout(() => {
-            textarea.style.height = 'auto'; // Reset height
-            textarea.style.height = `${textarea.scrollHeight}px`; // Adjust to content
-        }, 10); // Delay allows the browser to calculate scrollHeight
+        // Use requestAnimationFrame for better timing control
+        requestAnimationFrame(() => {
+            const currentHeight = textarea.offsetHeight;
+            textarea.style.height = '0px';
+            const newHeight = textarea.scrollHeight;
+
+            // Only update if needed
+            if (newHeight !== currentHeight) {
+                textarea.style.height = `${newHeight}px`;
+            } else {
+                textarea.style.height = `${currentHeight}px`;
+            }
+        });
     });
+
+    // Restore all scroll positions
+    if (docsSection) {
+        requestAnimationFrame(() => {
+            docsSection.scrollTop = savedScrollTop;
+            window.scrollTo(windowScrollX, windowScrollY);
+        });
+    }
 }
 
 


### PR DESCRIPTION
When a player or DM writes large notes, and the notes take all the screen height and make the page scrollbar appear, then every time the player or DM types a character, the scrollbar moves up, hiding the text being written. This is very frustrating to write large notes.

This fix makes the scrollbar remain at the same editing position when typing (but the user still can move the scrollbar explicitly).