### PR TITLE
Homebrew give-to-player fixes, monster bonus actions, and modal sizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .localstorage
 YOUTUBE_WALKTHROUGH_SCRIPT.md
+
+# DM-provided content that must not be published (see docs/README_LOCAL_CONTENT.md)
+local-content/

--- a/CharacterCreator/CharacterCreator.css
+++ b/CharacterCreator/CharacterCreator.css
@@ -314,6 +314,11 @@ body {
     border-bottom: 1px solid var(--cc-border);
     width: 100%;
     overflow: hidden;
+    /* Follow the container's rounded corners so the active/hover tab tint is
+       clipped to the curve instead of squaring off over the rounded bubble
+       (container radius 14px minus its 1px border = 13px inner radius). */
+    border-top-left-radius: 13px;
+    border-top-right-radius: 13px;
 }
 
 .nav-tab {

--- a/CharacterCreator/CharacterCreator.js
+++ b/CharacterCreator/CharacterCreator.js
@@ -72,7 +72,8 @@ let currentCharacter = {
     savingThrows: {},
     skills: {
         proficiencies: [],
-        sources: {} // Track where each skill came from
+        sources: {}, // Track where each skill came from
+        expertise: [] // Skills with doubled proficiency (rogue/bard)
     },
     languages: {
         proficiencies: [],
@@ -245,11 +246,19 @@ async function readSpellJson() {
         if (!response.ok) throw new Error('Network response was not ok');
         const spellsData = await response.json();
 
-        let combinedData = isGlobalDataAnObject 
+        // Optional DM-provided spells: same shape as spells-eng.json entries.
+        // A local spell with the same name and year replaces the shipped one.
+        const localSpells = (await loadLocalContentJson('../local-content/spells.json')) || [];
+        const localSpellKeys = new Set(localSpells.map(s => `${(s.name || '').toLowerCase()}|${s.year || '2014'}`));
+        const officialSpells = localSpellKeys.size
+            ? spellsData.filter(s => !localSpellKeys.has(`${(s.name || '').toLowerCase()}|${s.year || '2014'}`))
+            : spellsData;
+
+        let combinedData = isGlobalDataAnObject
             ? Object.values(allSpellData)
             : allSpellData;
-        
-        combinedData = [...combinedData, ...spellsData];
+
+        combinedData = [...combinedData, ...officialSpells, ...localSpells];
 
         const versionData = await loadDataFromGlobalStorage("D&DVersion");
         const versionSetting = versionData?.Version || '2014';
@@ -1028,7 +1037,7 @@ function updateSkillOptionDisplays() {
             
             const takenSkills = getTakenSkills(availableSkills);
             if (takenSkills.length > 0) {
-                warning.innerHTML = `<strong>Already taken:</strong> ${takenSkills.map(skill => 
+                warning.innerHTML = `<strong>Already taken:</strong> ${takenSkills.map(skill =>
                     `${skill} (${getSkillSource(skill)})`
                 ).join(', ')}`;
                 warning.style.display = 'block';
@@ -1037,6 +1046,11 @@ function updateSkillOptionDisplays() {
             }
         }
     });
+
+    // Expertise pickers list the character's proficient skills, so a change to
+    // skill proficiencies must refresh them (e.g. a rogue picking skills and
+    // expertise at the same level).
+    if (typeof refreshExpertiseChoices === 'function') refreshExpertiseChoices();
 }
 
 /**
@@ -1102,7 +1116,7 @@ function refreshSkillDisplays() {
             
             const takenSkills = getTakenSkills(availableSkills);
             if (takenSkills.length > 0) {
-                warning.innerHTML = `<strong>Already taken:</strong> ${takenSkills.map(skill => 
+                warning.innerHTML = `<strong>Already taken:</strong> ${takenSkills.map(skill =>
                     `${skill} (${getSkillSource(skill)})`
                 ).join(', ')}`;
                 warning.style.display = 'block';
@@ -1111,6 +1125,11 @@ function refreshSkillDisplays() {
             }
         }
     });
+
+    // Expertise pickers list the character's proficient skills, so a change to
+    // skill proficiencies must refresh them (e.g. a rogue picking skills and
+    // expertise at the same level).
+    if (typeof refreshExpertiseChoices === 'function') refreshExpertiseChoices();
 }
 
 

--- a/CharacterCreator/ClassCreator.js
+++ b/CharacterCreator/ClassCreator.js
@@ -488,11 +488,24 @@ function renderMulticlassRolledHitPointsInterface() {
     contentContainer.appendChild(inputsContainer);
     rolledContainer.appendChild(contentContainer);
     
-    // Add to the bottom of the multiclass header container
+    // Add to the bottom of the multiclass header container when it exists.
+    // A freshly selected single class is shown by displayClassInfoSection,
+    // which builds a `.class-header-container` instead — fall back to inserting
+    // right after it so the rolled-HP inputs still appear (previously they only
+    // showed up once a second class forced the multiclass view to render).
     const multiclassHeaderContainer = document.querySelector('.multiclass-header-container');
     if (multiclassHeaderContainer) {
         // Append directly to the multiclass header container so it's inside
         multiclassHeaderContainer.appendChild(rolledContainer);
+        return;
+    }
+
+    const classInfoDisplay = document.getElementById('classInfoDisplay');
+    const singleClassHeader = document.querySelector('.class-header-container');
+    if (singleClassHeader && singleClassHeader.parentNode) {
+        singleClassHeader.parentNode.insertBefore(rolledContainer, singleClassHeader.nextSibling);
+    } else if (classInfoDisplay) {
+        classInfoDisplay.appendChild(rolledContainer);
     }
 }
 
@@ -1018,6 +1031,17 @@ function renderMulticlassLevel(classData, classInfo, level, container) {
  * @param {string} className - Name of the class (for unique IDs)
  */
 function renderMulticlassChoices(parent, level, choiceKey, choiceDef, className) {
+    // Expertise and Magical Secrets carry only a placeholder option in the
+    // data; they need their own pickers (proficient skills / any-class spells).
+    if (isExpertiseChoiceKey(choiceKey)) {
+        renderExpertiseChoiceCard(parent, level, choiceKey, choiceDef, className);
+        return;
+    }
+    if (isMagicalSecretsChoiceKey(choiceKey)) {
+        renderMagicalSecretsChoiceCard(parent, level, choiceKey, choiceDef, className);
+        return;
+    }
+
     // Create unique IDs that include the class name to avoid conflicts
     const safeKey = choiceKey.replace(/[^a-zA-Z0-9_-]/g, '');
     const safeClassName = className.replace(/[^a-zA-Z0-9_-]/g, '');
@@ -1309,6 +1333,389 @@ function buildMulticlassMultipleChoice(body, status, choiceDef, level, choiceKey
         status.textContent = `❗ (${selectedChoices.length}/${choiceDef.choose})`;
         status.className = 'choice-status incomplete';
     }
+}
+
+// ========== SPECIAL CHOICE TYPES: EXPERTISE & MAGICAL SECRETS ==========
+//
+// Both are stored in Classes.json with a single placeholder option (e.g.
+// "Skill Expertise", "Any Class Spell") because the real options are dynamic:
+// expertise picks from the character's own skill proficiencies, and magical
+// secrets picks spells from any class list. These renderers replace the generic
+// checkbox interface for those choice keys in both the single-class and
+// multiclass views.
+
+/** Expertise choice keys are exactly "Expertise" today, but match loosely so
+ *  homebrew "... Expertise" skill choices are handled too. Feature-only
+ *  entries (e.g. Assassin's "Infiltration Expertise") never reach here because
+ *  only `choices` entries are rendered through renderChoices. */
+function isExpertiseChoiceKey(choiceKey) {
+    return /\bexpertise\b/i.test(choiceKey);
+}
+
+function isMagicalSecretsChoiceKey(choiceKey) {
+    return /magical secrets/i.test(choiceKey);
+}
+
+/** Resolve the class entry a choice belongs to. Multiclass passes the name;
+ *  single-class falls back to the only/primary class. */
+function resolveChoiceClassName(className) {
+    if (className) return className;
+    if (currentCharacter.classes && currentCharacter.classes[0]) {
+        return currentCharacter.classes[0].className;
+    }
+    return currentCharacter.class || null;
+}
+
+function classDisplayName(className) {
+    return classesData?.classes?.[className]?.name || className || 'class';
+}
+
+/** Store an array/object choice value on the owning class entry (mirrors what
+ *  handleChoiceSelection does, but without the duplicate-tracking validation
+ *  that would reject skill/spell names). */
+function storeSpecialChoiceValue(level, choiceKey, ownerClass, value) {
+    const targetClass = ownerClass
+        ? currentCharacter.classes.find(c => c.className === ownerClass)
+        : (currentCharacter.classes && currentCharacter.classes[0]);
+    if (targetClass) {
+        targetClass.choices = targetClass.choices || {};
+        targetClass.choices[level] = targetClass.choices[level] || {};
+        targetClass.choices[level][choiceKey] = value;
+    } else {
+        currentCharacter.choices = currentCharacter.choices || {};
+        currentCharacter.choices[level] = currentCharacter.choices[level] || {};
+        currentCharacter.choices[level][choiceKey] = value;
+    }
+    if (typeof updateClassesDataForSave === 'function') updateClassesDataForSave();
+}
+
+function setChoiceCountStatus(status, count, needed) {
+    if (count >= needed) {
+        status.textContent = '✔';
+        status.className = 'choice-status complete';
+    } else {
+        status.textContent = count > 0 ? `❗ (${count}/${needed})` : '❗';
+        status.className = 'choice-status incomplete';
+    }
+}
+
+// ---- Expertise ----
+
+function addExpertiseSkill(skill) {
+    currentCharacter.skills = currentCharacter.skills || {};
+    currentCharacter.skills.expertise = currentCharacter.skills.expertise || [];
+    if (!currentCharacter.skills.expertise.includes(skill)) {
+        currentCharacter.skills.expertise.push(skill);
+    }
+}
+
+function removeExpertiseSkill(skill) {
+    if (!currentCharacter.skills || !Array.isArray(currentCharacter.skills.expertise)) return;
+    const idx = currentCharacter.skills.expertise.indexOf(skill);
+    if (idx > -1) currentCharacter.skills.expertise.splice(idx, 1);
+}
+
+/** Renders the expertise picker card. Rebuildable so it can refresh when the
+ *  character's skill proficiencies change (rogue picks skills and expertise at
+ *  the same level). */
+function renderExpertiseChoiceCard(parent, level, choiceKey, choiceDef, className) {
+    const ownerClass = resolveChoiceClassName(className);
+    const safeKey = choiceKey.replace(/[^a-zA-Z0-9_-]/g, '');
+    const safeClass = (ownerClass || 'class').replace(/[^a-zA-Z0-9_-]/g, '');
+    const idBase = `expertise-${safeClass}-${safeKey}-L${level}`;
+
+    const existing = document.getElementById(`${idBase}-card`);
+    if (existing) existing.remove();
+
+    const chooseCount = choiceDef.choose || 2;
+    const { card, header, body } = renderSimpleCard(
+        parent,
+        `${choiceKey} (choose ${chooseCount})`,
+        choiceDef.description || '',
+        idBase
+    );
+    card.id = `${idBase}-card`;
+    card.classList.add('expertise-choice-card');
+
+    const status = document.createElement('span');
+    status.classList.add('choice-status', 'incomplete');
+    status.textContent = '❗';
+    header.insertBefore(status, header.firstChild);
+
+    const build = () => buildExpertiseInterface(body, status, level, choiceKey, ownerClass, chooseCount);
+    // Stash for refreshExpertiseChoices() to call when proficiencies change
+    card._rebuildExpertise = build;
+    build();
+}
+
+function buildExpertiseInterface(body, status, level, choiceKey, ownerClass, chooseCount) {
+    body.innerHTML = '';
+
+    let selected = getSavedChoiceValue(level, choiceKey, ownerClass);
+    selected = Array.isArray(selected) ? selected.filter(s => typeof s === 'string') : [];
+
+    const proficientSkills = [...(currentCharacter.skills?.proficiencies || [])].sort();
+
+    if (proficientSkills.length === 0) {
+        const note = document.createElement('p');
+        note.className = 'equipment-note';
+        note.textContent = 'Choose your skill proficiencies first — expertise doubles your ' +
+            'proficiency bonus for skills you are already proficient in.';
+        body.appendChild(note);
+        setChoiceCountStatus(status, selected.length, chooseCount);
+        return;
+    }
+
+    const instruction = document.createElement('p');
+    instruction.className = 'multi-choice-instruction';
+    instruction.textContent = `Choose ${chooseCount} skill${chooseCount > 1 ? 's' : ''} to gain ` +
+        `expertise in (proficiency bonus doubled):`;
+    body.appendChild(instruction);
+
+    const container = document.createElement('div');
+    container.className = 'multi-choice-container';
+
+    proficientSkills.forEach((skill, i) => {
+        const isSelectedHere = selected.includes(skill);
+        // Expertise already assigned by a different expertise choice/source
+        const takenElsewhere = (currentCharacter.skills?.expertise || []).includes(skill) && !isSelectedHere;
+
+        const optionDiv = document.createElement('div');
+        optionDiv.className = 'multi-choice-option';
+        if (takenElsewhere) optionDiv.classList.add('skill-taken');
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.id = `expertise-${level}-${choiceKey.replace(/[^a-zA-Z0-9_-]/g, '')}-opt-${i}`;
+        checkbox.value = skill;
+        checkbox.checked = isSelectedHere;
+        checkbox.disabled = takenElsewhere;
+
+        const label = document.createElement('label');
+        label.htmlFor = checkbox.id;
+        label.textContent = takenElsewhere ? `${skill} (expertise already assigned)` : skill;
+
+        checkbox.addEventListener('change', () => {
+            if (checkbox.checked) {
+                if (selected.length >= chooseCount) {
+                    checkbox.checked = false;
+                    return;
+                }
+                selected.push(skill);
+                addExpertiseSkill(skill);
+            } else {
+                const idx = selected.indexOf(skill);
+                if (idx > -1) selected.splice(idx, 1);
+                removeExpertiseSkill(skill);
+            }
+            storeSpecialChoiceValue(level, choiceKey, ownerClass, [...selected]);
+            setChoiceCountStatus(status, selected.length, chooseCount);
+            // Other expertise cards must update their "already assigned" marks
+            refreshExpertiseChoices();
+        });
+
+        optionDiv.appendChild(checkbox);
+        optionDiv.appendChild(label);
+        container.appendChild(optionDiv);
+    });
+
+    body.appendChild(container);
+    setChoiceCountStatus(status, selected.length, chooseCount);
+}
+
+/** Re-render every expertise card in place. Called when skill proficiencies
+ *  change so newly-picked skills become available for expertise. */
+function refreshExpertiseChoices() {
+    document.querySelectorAll('.expertise-choice-card').forEach(card => {
+        if (typeof card._rebuildExpertise === 'function') card._rebuildExpertise();
+    });
+}
+
+// ---- Magical Secrets ----
+
+const MAGICAL_SECRETS_SOURCE_CLASSES =
+    ['Bard', 'Cleric', 'Druid', 'Paladin', 'Ranger', 'Sorcerer', 'Warlock', 'Wizard'];
+
+function getMagicalSecretsStore() {
+    if (!currentCharacter.magicalSecrets) currentCharacter.magicalSecrets = {};
+    return currentCharacter.magicalSecrets;
+}
+
+function magicalSecretsKey(ownerClass, level, choiceKey) {
+    return `${ownerClass || 'class'}-L${level}-${choiceKey}`;
+}
+
+/** Highest spell level the owning class can cast (from its own slot table),
+ *  which bounds magical-secrets picks. Cantrips are always allowed. */
+function getMagicalSecretsMaxSpellLevel(ownerClass) {
+    const entry = (currentCharacter.classes || []).find(c => c.className === ownerClass);
+    if (entry && typeof getSpellBudgetForClass === 'function') {
+        const budget = getSpellBudgetForClass(entry);
+        if (budget && budget.maxSpellLevel) return budget.maxSpellLevel;
+    }
+    return 9;
+}
+
+function renderMagicalSecretsChoiceCard(parent, level, choiceKey, choiceDef, className) {
+    const ownerClass = resolveChoiceClassName(className);
+    const safeKey = choiceKey.replace(/[^a-zA-Z0-9_-]/g, '');
+    const safeClass = (ownerClass || 'class').replace(/[^a-zA-Z0-9_-]/g, '');
+    const idBase = `magicsecrets-${safeClass}-${safeKey}-L${level}`;
+
+    const existing = document.getElementById(`${idBase}-card`);
+    if (existing) existing.remove();
+
+    const chooseCount = choiceDef.choose || 2;
+    const { card, header, body } = renderSimpleCard(
+        parent,
+        `${choiceKey} (choose ${chooseCount})`,
+        choiceDef.description || '',
+        idBase
+    );
+    card.id = `${idBase}-card`;
+    card.classList.add('magic-secrets-choice-card');
+
+    const status = document.createElement('span');
+    status.classList.add('choice-status', 'incomplete');
+    status.textContent = '❗';
+    header.insertBefore(status, header.firstChild);
+
+    buildMagicalSecretsInterface(body, status, level, choiceKey, ownerClass, chooseCount);
+}
+
+function buildMagicalSecretsInterface(body, status, level, choiceKey, ownerClass, chooseCount) {
+    body.innerHTML = '';
+
+    const store = getMagicalSecretsStore();
+    const key = magicalSecretsKey(ownerClass, level, choiceKey);
+    const entry = store[key] = store[key] || {};
+    entry.ownerClass = ownerClass;
+    entry.level = level;
+    entry.choiceKey = choiceKey;
+    entry.sourceClass = entry.sourceClass || '';
+    entry.spells = Array.isArray(entry.spells) ? entry.spells : [];
+
+    // Recomputed on each render: the class level can change after this card is
+    // first built (level-up appends the card before syncing the class level).
+    const note = document.createElement('p');
+    note.className = 'equipment-note';
+    body.appendChild(note);
+    const updateNote = (maxLevel) => {
+        note.textContent = `Choose ${chooseCount} spell${chooseCount > 1 ? 's' : ''} from any class's ` +
+            `spell list — a cantrip or a spell up to level ${maxLevel}. They count as ` +
+            `${classDisplayName(ownerClass)} spells and are added to your sheet.`;
+    };
+
+    const select = document.createElement('select');
+    select.className = 'choice-select';
+    select.appendChild(new Option('-- select a class to browse --', ''));
+    MAGICAL_SECRETS_SOURCE_CLASSES.forEach(c => select.appendChild(new Option(c, c)));
+    if (entry.sourceClass) select.value = entry.sourceClass;
+    body.appendChild(select);
+
+    const counter = document.createElement('p');
+    counter.className = 'spell-counters';
+    body.appendChild(counter);
+
+    const listContainer = document.createElement('div');
+    listContainer.className = 'magic-secrets-spell-list';
+    body.appendChild(listContainer);
+
+    const updateCounter = () => {
+        counter.textContent = `Selected: ${entry.spells.length}/${chooseCount}`;
+        counter.className = 'spell-counters' + (entry.spells.length >= chooseCount ? ' spell-counters-complete' : '');
+        setChoiceCountStatus(status, entry.spells.length, chooseCount);
+    };
+
+    const renderList = () => {
+        const maxLevel = getMagicalSecretsMaxSpellLevel(ownerClass);
+        updateNote(maxLevel);
+        listContainer.innerHTML = '';
+        const cls = select.value;
+        if (!cls) {
+            const hint = document.createElement('p');
+            hint.className = 'equipment-note';
+            hint.textContent = 'Select a class above to browse its spells.';
+            listContainer.appendChild(hint);
+            return;
+        }
+
+        const allSpells = (typeof AppData !== 'undefined' && AppData?.spellLookupInfo?.spellsData) || [];
+        if (allSpells.length === 0) {
+            const hint = document.createElement('p');
+            hint.className = 'equipment-note';
+            hint.textContent = 'Spell list is still loading — open the Spells tab once, then return here.';
+            listContainer.appendChild(hint);
+            return;
+        }
+
+        const options = allSpells.filter(sp => {
+            const lvl = spellCatalogLevel(sp);
+            if (lvl > maxLevel) return false;
+            const list = (sp.class || '').split(',').map(x => x.trim());
+            return list.includes(cls);
+        });
+
+        for (let lvl = 0; lvl <= maxLevel; lvl++) {
+            const group = options
+                .filter(s => spellCatalogLevel(s) === lvl)
+                .sort((a, b) => a.name.localeCompare(b.name));
+            if (group.length === 0) continue;
+
+            const details = document.createElement('details');
+            details.className = 'spell-level-group';
+            details.open = (lvl <= 1);
+            const summary = document.createElement('summary');
+            summary.textContent = lvl === 0 ? `Cantrips (${group.length})` : `Level ${lvl} (${group.length})`;
+            details.appendChild(summary);
+
+            group.forEach(sp => {
+                const row = document.createElement('div');
+                row.className = 'multi-choice-option';
+
+                const cb = document.createElement('input');
+                cb.type = 'checkbox';
+                cb.value = sp.name;
+                cb.checked = entry.spells.includes(sp.name);
+
+                const label = document.createElement('label');
+                label.textContent = `${sp.name}${sp.school ? ` — ${sp.school}` : ''}`;
+
+                cb.addEventListener('change', () => {
+                    if (cb.checked) {
+                        if (entry.spells.length >= chooseCount) {
+                            cb.checked = false;
+                            if (typeof showError === 'function') {
+                                showError(`You can only choose ${chooseCount} spells for ${choiceKey}.`);
+                            }
+                            return;
+                        }
+                        if (!entry.spells.includes(sp.name)) entry.spells.push(sp.name);
+                    } else {
+                        const i = entry.spells.indexOf(sp.name);
+                        if (i > -1) entry.spells.splice(i, 1);
+                    }
+                    entry.sourceClass = select.value;
+                    if (typeof updateClassesDataForSave === 'function') updateClassesDataForSave();
+                    updateCounter();
+                });
+
+                row.appendChild(cb);
+                row.appendChild(label);
+                details.appendChild(row);
+            });
+
+            listContainer.appendChild(details);
+        }
+    };
+
+    select.onchange = () => {
+        entry.sourceClass = select.value;
+        renderList();
+    };
+
+    renderList();
+    updateCounter();
 }
 
 /**
@@ -2987,23 +3394,169 @@ function renderLevel1CharacterCreation(parent, className) {
             equipmentList.appendChild(weaponItem);
         }
         
-        if (classInfo.equipmentProficiencies.tools && classInfo.equipmentProficiencies.tools.length > 0) {
+        // Tools split into fixed grants (shown as text) and count-based picks
+        // ("Three Musical Instruments" etc.) that need a selection interface.
+        const toolEntries = classInfo.equipmentProficiencies.tools || [];
+        const fixedTools = toolEntries.filter(t => !parseClassToolChoice(t));
+        const choiceTools = toolEntries.filter(t => parseClassToolChoice(t));
+
+        if (fixedTools.length > 0) {
             const toolItem = document.createElement('li');
-            toolItem.innerHTML = `<strong>Tools:</strong> ${classInfo.equipmentProficiencies.tools.join(', ')}`;
+            toolItem.innerHTML = `<strong>Tools:</strong> ${fixedTools.join(', ')}`;
             equipmentList.appendChild(toolItem);
         }
-        
+
         if (classInfo.equipmentProficiencies.other && classInfo.equipmentProficiencies.other.length > 0) {
             const otherItem = document.createElement('li');
             otherItem.innerHTML = `<strong>Other:</strong> ${classInfo.equipmentProficiencies.other.join(', ')}`;
             equipmentList.appendChild(otherItem);
         }
-        
+
         body.appendChild(equipmentList);
-        
+
+        // Grant the fixed tool proficiencies to the character
+        fixedTools.forEach(tool => {
+            if (!hasToolProficiency(tool)) addToolProficiency(tool, `${classInfo.name} Class`);
+        });
+
+        // Render a picker for each count-based tool proficiency
+        choiceTools.forEach(entry => {
+            renderClassToolChoice(body, entry, classInfo.name);
+        });
+
         // Store equipment proficiencies in character
         currentCharacter.equipmentProficiencies = classInfo.equipmentProficiencies;
     }
+}
+
+// "Count-word category" tool proficiency grants (e.g. "Three Musical
+// Instruments", "One Artisan Tool") expand into a pick from these lists.
+const CLASS_TOOL_CATEGORY_OPTIONS = {
+    'musical instrument': [
+        "Bagpipes", "Drum", "Dulcimer", "Flute", "Horn",
+        "Lute", "Lyre", "Pan flute", "Shawm", "Viol"
+    ],
+    'artisan tool': [
+        "Alchemist's supplies", "Brewer's supplies", "Calligrapher's supplies",
+        "Carpenter's tools", "Cartographer's tools", "Cobbler's tools",
+        "Cook's utensils", "Glassblower's tools", "Jeweler's tools",
+        "Leatherworker's tools", "Mason's tools", "Painter's supplies",
+        "Potter's tools", "Smith's tools", "Tinker's tools",
+        "Weaver's tools", "Woodcarver's tools"
+    ],
+    'gaming set': [
+        "Dice set", "Dragonchess set", "Playing card set", "Three-Dragon Ante set"
+    ]
+};
+
+const TOOL_COUNT_WORDS = { one: 1, two: 2, three: 3, four: 4, five: 5 };
+
+/**
+ * Parses a count-based tool proficiency string like "Three Musical Instruments"
+ * or "One Artisan Tool" into { count, category, options }. Returns null for
+ * fixed grants ("Thieves' Tools", "Herbalism Kit") that need no selection.
+ */
+function parseClassToolChoice(entry) {
+    if (typeof entry !== 'string') return null;
+    const match = entry.trim().match(/^(one|two|three|four|five|\d+)\s+(.*)$/i);
+    if (!match) return null;
+
+    const count = TOOL_COUNT_WORDS[match[1].toLowerCase()] || parseInt(match[1], 10);
+    if (!count) return null;
+
+    // Normalise the category ("Musical Instruments" -> "musical instrument")
+    let cat = match[2].toLowerCase().replace(/[’']s\b/g, '').replace(/s\b/g, '').trim();
+    // Map common variants onto our category keys
+    if (cat.includes('musical instrument')) cat = 'musical instrument';
+    else if (cat.includes('artisan')) cat = 'artisan tool';
+    else if (cat.includes('gaming set')) cat = 'gaming set';
+
+    const options = CLASS_TOOL_CATEGORY_OPTIONS[cat];
+    if (!options) return null;
+
+    return { count, category: cat, options };
+}
+
+/**
+ * Renders a checkbox picker for a count-based class tool proficiency. Choices
+ * are stored in the character-wide choice store (so they persist and re-apply
+ * on load) and granted via addToolProficiency so they flow onto the sheet.
+ */
+function renderClassToolChoice(parent, entry, className) {
+    const parsed = parseClassToolChoice(entry);
+    if (!parsed) return;
+
+    const { count, options } = parsed;
+    const choiceKey = `class-tool-choice-${className}-${entry}`.replace(/\s+/g, '-').toLowerCase();
+    const source = `${className} Class`;
+
+    currentCharacter.choices = currentCharacter.choices || {};
+    let selected = currentCharacter.choices[choiceKey];
+    selected = Array.isArray(selected) ? selected.filter(t => typeof t === 'string') : [];
+
+    // Re-apply saved picks as proficiencies (relevant on load)
+    selected.forEach(tool => {
+        if (!hasToolProficiency(tool)) addToolProficiency(tool, source);
+    });
+
+    const container = document.createElement('div');
+    container.className = 'skill-selection-container tool-choice-container';
+
+    const instruction = document.createElement('p');
+    instruction.className = 'skill-instruction';
+    instruction.textContent = `Choose ${count} ${entry.replace(/^(one|two|three|four|five|\d+)\s+/i, '')}:`;
+    container.appendChild(instruction);
+
+    const status = document.createElement('span');
+    status.className = 'choice-status incomplete';
+    instruction.appendChild(status);
+
+    const updateStatus = () => setChoiceCountStatus(status, selected.length, count);
+
+    options.forEach((tool, i) => {
+        const isSelected = selected.includes(tool);
+        const takenElsewhere = hasToolProficiency(tool) && getToolSource(tool) !== source && !isSelected;
+
+        const optionDiv = document.createElement('div');
+        optionDiv.className = 'skill-option';
+        if (takenElsewhere) optionDiv.classList.add('skill-taken');
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.id = `${choiceKey}-opt-${i}`;
+        checkbox.value = tool;
+        checkbox.checked = isSelected;
+        checkbox.disabled = takenElsewhere;
+
+        const label = document.createElement('label');
+        label.htmlFor = checkbox.id;
+        label.textContent = takenElsewhere ? `${tool} (already taken)` : tool;
+
+        checkbox.addEventListener('change', () => {
+            if (checkbox.checked) {
+                if (selected.length >= count) {
+                    checkbox.checked = false;
+                    return;
+                }
+                selected.push(tool);
+                addToolProficiency(tool, source);
+            } else {
+                const idx = selected.indexOf(tool);
+                if (idx > -1) selected.splice(idx, 1);
+                if (getToolSource(tool) === source) removeToolProficiency(tool);
+            }
+            currentCharacter.choices[choiceKey] = [...selected];
+            if (typeof updateClassesDataForSave === 'function') updateClassesDataForSave();
+            updateStatus();
+        });
+
+        optionDiv.appendChild(checkbox);
+        optionDiv.appendChild(label);
+        container.appendChild(optionDiv);
+    });
+
+    parent.appendChild(container);
+    updateStatus();
 }
 
 /**
@@ -3078,6 +3631,17 @@ function getAllChoiceOptionsWithStatus(options, choiceKey) {
  * @param {boolean} hideUnavailable - If true, removes unavailable options; if false, shows them grayed out
  */
 function renderChoices(parent, level, choiceKey, choiceDef, hideUnavailable = true) {
+    // Expertise and Magical Secrets carry only a placeholder option in the
+    // data; they need their own pickers (proficient skills / any-class spells).
+    if (isExpertiseChoiceKey(choiceKey)) {
+        renderExpertiseChoiceCard(parent, level, choiceKey, choiceDef, null);
+        return;
+    }
+    if (isMagicalSecretsChoiceKey(choiceKey)) {
+        renderMagicalSecretsChoiceCard(parent, level, choiceKey, choiceDef, null);
+        return;
+    }
+
     // Sanitize the choiceKey so generated IDs are always valid CSS selectors
     const safeKey  = choiceKey.replace(/[^a-zA-Z0-9_-]/g, '');
     const idBase   = `choice-${safeKey}-L${level}`;

--- a/CharacterCreator/LoadCharacter.js
+++ b/CharacterCreator/LoadCharacter.js
@@ -6,6 +6,21 @@
 // added or changed and saved back non-destructively.
 // ============================================================================
 
+// Fetches an optional DM-provided JSON file from the gitignored local-content/
+// folder at the repo root (see docs/README_LOCAL_CONTENT.md). Returns null
+// when the file is absent or unparseable so callers fall through to shipped
+// data only. Also used by Species.js and CharacterCreator.js.
+async function loadLocalContentJson(path) {
+    try {
+        const response = await fetch(path);
+        if (!response.ok) return null;
+        return await response.json();
+    } catch (error) {
+        console.warn(`Local content file ${path} not loaded:`, error);
+        return null;
+    }
+}
+
 // Load classes data from JSON file
 async function loadClassesData() {
     try {
@@ -14,11 +29,66 @@ async function loadClassesData() {
             throw new Error('Failed to load classes data');
         }
         classesData = await response.json();
+        await mergeLocalClassesIntoClassesData();
+        await mergeLocalSubclassesIntoClassesData();
         await mergeCustomSubclassesIntoClassesData();
     } catch (error) {
         console.error('Error loading classes data:', error);
         throw error;
     }
+}
+
+/**
+ * Merges DM-provided classes (local-content/classes.json, same shape as
+ * Classes.json) into classesData. A local class with the same key as a
+ * built-in replaces it entirely, so a full-book version of a trimmed class
+ * can be dropped in; new keys add whole new classes (e.g. artificer).
+ */
+async function mergeLocalClassesIntoClassesData() {
+    const local = await loadLocalContentJson('../local-content/classes.json');
+    if (!local || !local.classes) return;
+    classesData.classes = classesData.classes || {};
+    Object.assign(classesData.classes, local.classes);
+}
+
+/**
+ * Merges DM-provided subclasses (local-content/subclasses.json) into
+ * classesData. Shape: { "<classKey>": { "<Subclass Name>": {...} } } where
+ * each definition matches the Classes.json subclass shape, plus an optional
+ * "year" ("2014"/"2024", default "2014") filtered by the D&DVersion setting
+ * like the spell catalog. Unlike homebrew subclasses, a local subclass with
+ * the same name as a built-in replaces it (to complete trimmed entries).
+ */
+async function mergeLocalSubclassesIntoClassesData() {
+    const local = await loadLocalContentJson('../local-content/subclasses.json');
+    if (!local) return;
+
+    const versionData = await loadDataFromGlobalStorage("D&DVersion");
+    const versionSetting = versionData?.Version || '2014';
+
+    Object.entries(local).forEach(([classKey, subs]) => {
+        const classInfo = classesData.classes?.[classKey];
+        if (!classInfo || !subs) return;
+        classInfo.subclasses = classInfo.subclasses || {};
+
+        Object.entries(subs).forEach(([subName, subDef]) => {
+            if (!subDef) return;
+            const year = subDef.year || '2014';
+            if (versionSetting !== 'both' && year !== versionSetting) return;
+
+            classInfo.subclasses[subName] = subDef;
+
+            // Offer it in the level-up subclass choice dropdown too
+            Object.values(classInfo.levelProgression || {}).forEach(levelData => {
+                Object.values(levelData.choices || {}).forEach(choiceDef => {
+                    if (choiceDef?.type === 'subclass' && Array.isArray(choiceDef.options) &&
+                        !choiceDef.options.includes(subName)) {
+                        choiceDef.options.push(subName);
+                    }
+                });
+            });
+        });
+    });
 }
 
 /**
@@ -86,10 +156,49 @@ async function loadFeatsData() {
             return;
         }
         featsData = await response.json();
+        // DM-provided feats (local-content/feats.json): a flat array of feat
+        // objects in the same shape as featsData.feats. Same-name entries
+        // replace built-ins; new names are appended.
+        const localFeats = await loadLocalContentJson('../local-content/feats.json');
+        if (Array.isArray(localFeats) && localFeats.length) {
+            featsData.feats = featsData.feats || [];
+            const byName = new Map(featsData.feats.map(f => [f.name, f]));
+            localFeats.forEach(f => byName.set(f.name, f));
+            featsData.feats = Array.from(byName.values());
+        }
+
+        // Homebrew feats (sheet Homebrew tab, global storage "Custom Feats"),
+        // filtered by the D&DVersion setting; new names are appended and never
+        // shadow a built-in or DM-provided feat.
+        try {
+            const customFeats = await loadDataFromGlobalStorage('Custom Feats');
+            if (customFeats && Object.keys(customFeats).length) {
+                const versionData = await loadDataFromGlobalStorage('D&DVersion');
+                const versionSetting = versionData?.Version || '2014';
+                featsData.feats = featsData.feats || [];
+                const byName = new Map(featsData.feats.map(f => [f.name, f]));
+                Object.values(customFeats).forEach(f => {
+                    if (!f || !f.name || byName.has(f.name)) return;
+                    const year = f.year || '2014';
+                    if (versionSetting !== 'both' && year !== versionSetting) return;
+                    byName.set(f.name, f);
+                });
+                featsData.feats = Array.from(byName.values());
+            }
+        } catch (error) {
+            console.error('Failed to merge custom feats:', error);
+        }
     } catch (error) {
         console.error('Error loading feats data:', error);
         featsData = {};
     }
+}
+
+// Slug used to key homebrew races into racesData (matches how the sheet's
+// Homebrew form stores them by name).
+function customRaceKey(name) {
+    return (name || '').toString().toLowerCase().normalize('NFKD')
+        .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 }
 
 // Load races data from JSON file
@@ -100,6 +209,30 @@ async function loadRacesData() {
             throw new Error('Failed to load races data');
         }
         racesData = await response.json();
+        // DM-provided races (local-content/races.json, same shape as
+        // Races.json): same-key entries replace built-ins, new keys add races
+        const localRaces = await loadLocalContentJson('../local-content/races.json');
+        if (localRaces) Object.assign(racesData, localRaces);
+
+        // Homebrew races (sheet Homebrew tab, global storage "Custom Races"),
+        // filtered by the D&DVersion setting; keyed by a slug of the name and
+        // never allowed to shadow a built-in / DM-provided race.
+        try {
+            const customRaces = await loadDataFromGlobalStorage('Custom Races');
+            if (customRaces && Object.keys(customRaces).length) {
+                const versionData = await loadDataFromGlobalStorage('D&DVersion');
+                const versionSetting = versionData?.Version || '2014';
+                Object.values(customRaces).forEach(race => {
+                    if (!race || !race.name) return;
+                    const year = race.year || '2014';
+                    if (versionSetting !== 'both' && year !== versionSetting) return;
+                    const key = customRaceKey(race.name);
+                    if (!racesData[key]) racesData[key] = race;
+                });
+            }
+        } catch (error) {
+            console.error('Failed to merge custom races:', error);
+        }
     } catch (error) {
         console.error('Error loading races data:', error);
         throw error;
@@ -346,6 +479,7 @@ function restoreFromCreatorData(ccd, characterName) {
 
     // --- Spell picks (editable again on level-up) ---
     currentCharacter.spellSelections = deepCopy(ccd.spellSelections || {});
+    currentCharacter.magicalSecrets = deepCopy(ccd.magicalSecrets || {});
 
     // --- Recompute HP and refresh derived save data ---
     updateMulticlassHitPoints();

--- a/CharacterCreator/SavingCharacter.js
+++ b/CharacterCreator/SavingCharacter.js
@@ -323,7 +323,13 @@ function buildEquipmentProficienciesForSave() {
 
         (source.weapons || []).forEach(w => weapons.add(normalizeProficiencyName(w)));
         (source.armor || []).forEach(a => armor.add(normalizeProficiencyName(a)));
-        (source.tools || []).forEach(t => tools.add(normalizeProficiencyName(t)));
+        (source.tools || []).forEach(t => {
+            // Count-based grants ("Three Musical Instruments") are represented by
+            // the specific tools the player picked (in currentCharacter.tools),
+            // so don't emit the placeholder string itself.
+            if (typeof parseClassToolChoice === 'function' && parseClassToolChoice(t)) return;
+            tools.add(normalizeProficiencyName(t));
+        });
     });
 
     // Racial proficiencies tracked on the character
@@ -567,6 +573,9 @@ function buildCharacterCreatorData() {
         // put into spellData (so the merge can tell creator spells from spells
         // the player added on the sheet).
         spellSelections: JSON.parse(JSON.stringify(currentCharacter.spellSelections || {})),
+        // Bard Magical Secrets (any-class spell picks that don't count against
+        // the class spells-known budget)
+        magicalSecrets: JSON.parse(JSON.stringify(currentCharacter.magicalSecrets || {})),
         creatorSpellsByLevel: typeof collectCreatorSpellsByLevel === 'function'
             ? collectCreatorSpellsByLevel()
             : {}

--- a/CharacterCreator/Species.js
+++ b/CharacterCreator/Species.js
@@ -623,6 +623,14 @@ function applyTraitEffects(traitName, choiceValue, speciesName) {
     
     // Find the trait in the species data
     const trait = speciesInfo.traits.find(t => t.name === traitName);
+
+    // Flexible ("choose your own") ASI applies its bonuses directly rather than
+    // through a static effects list (used on load to re-apply saved picks).
+    if (getFlexibleAsiConfig(trait, speciesInfo)) {
+        applyFlexibleAsiChoice(choiceValue, speciesInfo);
+        return;
+    }
+
     if (!trait || !trait.effects) return;
     
     // Apply the effects defined in the JSON data
@@ -871,8 +879,13 @@ function renderTraitCard(container, trait, speciesName) {
     // Handle trait choices if they exist
     if (trait.choices) {
         renderTraitChoices(body, trait, speciesName);
+    } else {
+        // Floating-ASI races (Goliath, etc.) carry a descriptive ASI trait with
+        // no choices block; render an interactive picker for it instead.
+        const asiConfig = getFlexibleAsiConfig(trait, racesData[speciesName]);
+        if (asiConfig) renderFlexibleAsiChoice(body, trait, speciesName, asiConfig);
     }
-    
+
     traitCard.appendChild(body);
     container.appendChild(traitCard);
 }
@@ -886,8 +899,11 @@ function renderTraitChoices(container, trait, speciesName) {
         renderSelectChoice(choicesContainer, trait, speciesName);
     } else if (trait.choices.type === 'multiple') {
         renderMultipleChoice(choicesContainer, trait, speciesName);
+    } else if (trait.choices.type === 'abilityScoreIncrease') {
+        renderFlexibleAsiChoice(choicesContainer, trait, speciesName,
+            getFlexibleAsiConfig(trait, racesData[speciesName]));
     }
-    
+
     container.appendChild(choicesContainer);
 }
 
@@ -1043,7 +1059,194 @@ function renderMultipleChoice(container, trait, speciesName) {
     updateChoiceCount(container, selectedChoices, choiceLimit);
 }
 
+// ========== FLEXIBLE ("choose your own") ABILITY SCORE INCREASE ==========
+//
+// Races with floating ability scores (2024-style, e.g. Goliath) used to render
+// a plain "apply this manually" note because the builder couldn't set the
+// bonuses. This makes those picks selectable right on the race, applies them to
+// the character immediately, and persists them via traitChoices.
 
+const FLEXIBLE_ASI_ABILITIES = [
+    { value: 'strength', label: 'Strength' },
+    { value: 'dexterity', label: 'Dexterity' },
+    { value: 'constitution', label: 'Constitution' },
+    { value: 'intelligence', label: 'Intelligence' },
+    { value: 'wisdom', label: 'Wisdom' },
+    { value: 'charisma', label: 'Charisma' }
+];
+
+// Default 5e (2024) distribution: +2/+1 to two abilities, or +1 to three.
+const DEFAULT_FLEXIBLE_ASI_CONFIG = {
+    type: 'abilityScoreIncrease',
+    modes: [
+        { key: '2-1', label: 'One ability +2 and a different one +1', values: [2, 1] },
+        { key: '1-1-1', label: 'Three different abilities +1', values: [1, 1, 1] }
+    ]
+};
+
+/**
+ * Returns the flexible-ASI config for a trait, or null if the trait isn't a
+ * choose-your-own ability score increase. Recognises an explicit data marker
+ * (`choices.type === 'abilityScoreIncrease'`) and, as a fallback, the
+ * generated "Ability Score Increase" note on a floating-ASI race (empty
+ * `abilityScoreIncrease`, no choices/effects of its own).
+ */
+function getFlexibleAsiConfig(trait, speciesInfo) {
+    if (!trait) return null;
+
+    if (trait.choices && trait.choices.type === 'abilityScoreIncrease') {
+        return {
+            type: 'abilityScoreIncrease',
+            modes: Array.isArray(trait.choices.modes) && trait.choices.modes.length
+                ? trait.choices.modes
+                : DEFAULT_FLEXIBLE_ASI_CONFIG.modes
+        };
+    }
+
+    const isAsiTrait = /ability score increase/i.test(trait.name || '');
+    const raceAsiEmpty = !speciesInfo || !speciesInfo.abilityScoreIncrease ||
+        Object.keys(speciesInfo.abilityScoreIncrease).length === 0;
+    if (isAsiTrait && raceAsiEmpty && !trait.choices && !trait.effects) {
+        return DEFAULT_FLEXIBLE_ASI_CONFIG;
+    }
+    return null;
+}
+
+function flexibleAsiSource(speciesInfo) {
+    return `${speciesInfo.name} ASI Choice`;
+}
+
+/** Clear then (re)apply the ability bonuses for a flexible ASI selection. */
+function applyFlexibleAsiChoice(choiceValue, speciesInfo) {
+    const source = flexibleAsiSource(speciesInfo);
+    ['strength', 'dexterity', 'constitution', 'intelligence', 'wisdom', 'charisma']
+        .forEach(ability => removeAbilityBonus(ability, source));
+
+    if (choiceValue && Array.isArray(choiceValue.picks)) {
+        // Guard against duplicate abilities landing on the sheet
+        const used = new Set();
+        choiceValue.picks.forEach(pick => {
+            if (pick && pick.ability && pick.value && !used.has(pick.ability)) {
+                used.add(pick.ability);
+                addAbilityBonus(pick.ability, pick.value, source);
+            }
+        });
+    }
+
+    updateAbilityBonuses();
+    if (typeof updateAbilityTotalsUI === 'function') updateAbilityTotalsUI();
+    if (typeof updateAbilityModifiers === 'function') updateAbilityModifiers();
+}
+
+/**
+ * Renders the interactive flexible-ASI picker: a distribution mode selector
+ * plus one ability dropdown per increase, enforcing distinct abilities.
+ */
+function renderFlexibleAsiChoice(container, trait, speciesName, config) {
+    const speciesInfo = racesData[speciesName];
+
+    const wrap = document.createElement('div');
+    wrap.className = 'trait-choices flexible-asi-choice';
+
+    const label = document.createElement('p');
+    label.textContent = 'Assign your ability score increases: ';
+    const status = document.createElement('span');
+    status.className = 'choice-status incomplete';
+    status.textContent = '❗';
+    label.appendChild(status);
+    wrap.appendChild(label);
+
+    const modeSelect = document.createElement('select');
+    modeSelect.className = 'trait-choice-select';
+    config.modes.forEach(m => modeSelect.appendChild(new Option(m.label, m.key)));
+    wrap.appendChild(modeSelect);
+
+    const picksContainer = document.createElement('div');
+    picksContainer.className = 'flexible-asi-picks';
+    wrap.appendChild(picksContainer);
+
+    const saved = currentCharacter.traitChoices && currentCharacter.traitChoices[trait.name];
+    modeSelect.value = (saved && saved.mode) || config.modes[0].key;
+
+    const getMode = () => config.modes.find(m => m.key === modeSelect.value) || config.modes[0];
+
+    const refreshOptionStates = () => {
+        const selects = [...picksContainer.querySelectorAll('select')];
+        const chosen = selects.map(s => s.value).filter(Boolean);
+        selects.forEach(s => {
+            [...s.options].forEach(o => {
+                if (!o.value) return;
+                o.disabled = chosen.includes(o.value) && s.value !== o.value;
+            });
+        });
+    };
+
+    const commit = () => {
+        const mode = getMode();
+        const selects = [...picksContainer.querySelectorAll('select')];
+        const picks = [];
+        selects.forEach((s, i) => {
+            if (s.value) picks.push({ ability: s.value, value: mode.values[i] });
+        });
+
+        const choiceValue = { mode: mode.key, picks };
+        currentCharacter.traitChoices = currentCharacter.traitChoices || {};
+        currentCharacter.traitChoices[trait.name] = choiceValue;
+
+        applyFlexibleAsiChoice(choiceValue, speciesInfo);
+
+        const complete = picks.length === mode.values.length;
+        status.textContent = complete ? '✔' : '❗';
+        status.className = complete ? 'choice-status complete' : 'choice-status incomplete';
+
+        if (typeof updateRacesDataForSave === 'function') updateRacesDataForSave();
+        refreshOptionStates();
+    };
+
+    const buildPicks = () => {
+        picksContainer.innerHTML = '';
+        const mode = getMode();
+        const savedPicks = (saved && saved.mode === mode.key && Array.isArray(saved.picks)) ? saved.picks : [];
+
+        mode.values.forEach((val, i) => {
+            const row = document.createElement('div');
+            row.className = 'flexible-asi-row';
+
+            const rowLabel = document.createElement('label');
+            rowLabel.textContent = `+${val} to `;
+            row.appendChild(rowLabel);
+
+            const sel = document.createElement('select');
+            sel.className = 'trait-choice-select';
+            sel.appendChild(new Option('-- select ability --', ''));
+            FLEXIBLE_ASI_ABILITIES.forEach(a => sel.appendChild(new Option(a.label, a.value)));
+            if (savedPicks[i] && savedPicks[i].ability) sel.value = savedPicks[i].ability;
+
+            sel.addEventListener('change', () => {
+                const others = [...picksContainer.querySelectorAll('select')]
+                    .filter(s => s !== sel).map(s => s.value);
+                if (sel.value && others.includes(sel.value)) {
+                    if (typeof showError === 'function') {
+                        showError('Choose a different ability — each increase must go to a distinct score.');
+                    }
+                    sel.value = '';
+                }
+                commit();
+            });
+
+            row.appendChild(sel);
+            picksContainer.appendChild(row);
+        });
+        refreshOptionStates();
+    };
+
+    modeSelect.addEventListener('change', () => { buildPicks(); commit(); });
+
+    buildPicks();
+    commit(); // reflect any saved picks (and re-apply their bonuses)
+
+    container.appendChild(wrap);
+}
 
 
 
@@ -1081,8 +1284,11 @@ function openSpeciesModal(speciesName) {
     asiDiv.className = 'species-asi';
     if (asi.all) {
         asiDiv.innerHTML = `<p><strong>Ability Score Increase:</strong> +1 to all abilities</p>`;
+    } else if (!asi || Object.keys(asi).length === 0) {
+        // Floating-ASI race: increases are chosen after selecting the race
+        asiDiv.innerHTML = `<p><strong>Ability Score Increase:</strong> Choose your own (set after selecting this race)</p>`;
     } else {
-        const asiList = Object.entries(asi).map(([ability, value]) => 
+        const asiList = Object.entries(asi).map(([ability, value]) =>
             `+${value} ${ability.charAt(0).toUpperCase() + ability.slice(1)}`
         ).join(', ');
         asiDiv.innerHTML = `<p><strong>Ability Score Increase:</strong> ${asiList}</p>`;
@@ -1341,10 +1547,27 @@ function applyRacialToolProficiencies(raceName) {
 
 // Apply subrace features
 function applySubraceFeatures(raceName, subraceKey, subrace) {
-    // Apply subrace ability score increases
+    // Apply subrace ability score increases.
+    // Most subraces carry the same increase in BOTH `abilityScoreIncrease` and a
+    // `bonuses` entry; the latter is already applied by applyRacialBonuses, so
+    // only apply increases here that the bonuses array doesn't already cover.
+    // That fixes double-counting (e.g. Hill Dwarf Wisdom, Mountain Dwarf
+    // Strength) while still supporting subraces that only define
+    // `abilityScoreIncrease`.
     if (subrace.abilityScoreIncrease) {
+        const ABBR_TO_ABILITY = {
+            STR: 'strength', DEX: 'dexterity', CON: 'constitution',
+            INT: 'intelligence', WIS: 'wisdom', CHA: 'charisma'
+        };
+        const coveredByBonuses = new Set(
+            (subrace.bonuses || [])
+                .filter(b => b.category === 'attributes' && ABBR_TO_ABILITY[b.key])
+                .map(b => ABBR_TO_ABILITY[b.key])
+        );
         Object.entries(subrace.abilityScoreIncrease).forEach(([ability, value]) => {
-            addAbilityBonus(ability, value, `${subrace.name} Subrace`);
+            if (!coveredByBonuses.has(ability)) {
+                addAbilityBonus(ability, value, `${subrace.name} Subrace`);
+            }
         });
     }
     
@@ -1623,16 +1846,27 @@ function validateRaceData() {
  * Fetches race data from JSON file
  */
 async function fetchRaceDataFromJSON(raceKey) {
+    // DM-provided races take priority, mirroring the merge in loadRacesData
+    const localRaces = await loadLocalContentJson('../local-content/races.json');
+    if (localRaces && localRaces[raceKey]) {
+        return localRaces[raceKey];
+    }
+
     const response = await fetch('./Races.json');
     const originalRacesData = await response.json();
     const speciesInfo = originalRacesData[raceKey];
-    
-    if (!speciesInfo) {
-        console.error(`Race "${raceKey}" not found in Races.json`);
-        return null;
+
+    if (speciesInfo) return speciesInfo;
+
+    // Homebrew races (global storage "Custom Races") are merged into racesData
+    // by loadRacesData but aren't in Races.json / local-content; fall back to
+    // the already-merged in-memory copy.
+    if (typeof racesData !== 'undefined' && racesData && racesData[raceKey]) {
+        return racesData[raceKey];
     }
-    
-    return speciesInfo;
+
+    console.error(`Race "${raceKey}" not found in Races.json`);
+    return null;
 }
 
 /**

--- a/CharacterCreator/Spells.js
+++ b/CharacterCreator/Spells.js
@@ -163,11 +163,18 @@ function getSubclassDisplayName(clsEntry) {
     return info?.subclasses?.[clsEntry.subclass]?.name || clsEntry.subclass;
 }
 
-/** Loose match between a subclass name and a catalog tag field. */
+/**
+ * Loose match between a subclass name and a catalog tag field, on whole-word
+ * boundaries so e.g. the "Light" domain tag doesn't match "Twilight Domain".
+ */
 function subclassMatchesField(subclassDisplay, fieldValue) {
     const tags = String(fieldValue).split(',').map(t => t.trim().toLowerCase());
     const name = subclassDisplay.toLowerCase();
-    return tags.some(tag => tag && (name.includes(tag) || tag.includes(name)));
+    const wordMatch = (needle, haystack) => {
+        const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        return new RegExp(`\\b${escaped}\\b`).test(haystack);
+    };
+    return tags.some(tag => tag && (wordMatch(tag, name) || wordMatch(name, tag)));
 }
 
 /**
@@ -280,6 +287,17 @@ function collectCreatorSpellsByLevel() {
         (picks.cantrips || []).forEach(add);
         (picks.spells || []).forEach(add);
         getAutoGrantedSpells(clsEntry, budget).forEach(spell => add(spell.name));
+    });
+
+    // Magical Secrets (bard, and similar "any class" grants) — extra spells that
+    // don't count against a class's normal spells-known budget. Only include
+    // entries whose owning class is still on the character at the required level.
+    Object.values(currentCharacter.magicalSecrets || {}).forEach(entry => {
+        if (!entry || !Array.isArray(entry.spells) || entry.spells.length === 0) return;
+        const owner = entries.find(c => c.className === entry.ownerClass);
+        if (!owner) return;
+        if (entry.level && (owner.level || 1) < entry.level) return;
+        entry.spells.forEach(add);
     });
 
     return result;

--- a/DMScreen.html
+++ b/DMScreen.html
@@ -148,6 +148,8 @@
                         <!-- Actions -->
                         <div id="monsterActions" class="monster-actions"></div>
                         <hr id="monsterActionsHR" class="monsterActionsDivider">
+                        <div id="monsterBonusActions" class="monster-actions"></div>
+                        <hr id="monsterBonusActionsHR" class="monsterActionsDivider">
                         <div id="monsterReactions" class="monster-actions"></div>
                         <hr id="monsterActionsHR" class="monsterActionsDivider">
                         <div id="monsterLegendaryActions" class="monster-actions"></div>
@@ -1065,7 +1067,12 @@
                     <legend id="actionsLegend">Actions</legend>
                     <button type="button" id="addActionButton" class="nonRollButton">Add Action</button>
                 </fieldset>
-        
+
+                <fieldset id="monsterFormBonusActions">
+                    <legend id="bonusActionsLegend">Bonus Actions</legend>
+                    <button type="button" id="addBonusActionButton" class="nonRollButton">Add Bonus Action</button>
+                </fieldset>
+
                 <fieldset id="monsterFormReactions">
                     <legend id="reactionsLegend">Reactions</legend>
                     <button type="button" id="addReactionButton" class="nonRollButton">Add Reaction</button>
@@ -1523,6 +1530,38 @@
                         <hr>
                         <div class="monsterEditorSubsection">
                             <div>
+                                <button id="customRaces" class="nonRollButton">Create Race</button>
+                                <button id="importCustomRace" class="nonRollButton">Import Race</button>
+                            </div>
+                            <div class="deleteMonster">
+                                <div class="deleteMonster-header">
+                                    <label id="customRaceSelectLabel" for="customRaceSelect">Select Race to Delete/Edit:</label>
+                                    <button id="deleteCustomRaces" class="nonRollButton">Delete Race</button>
+                                    <button id="editCustomRaces" class="nonRollButton">Edit Race</button>
+                                    <button id="exportCustomRace" class="nonRollButton">Export Race</button>
+                                </div>
+                                <select id="customRaceSelect"></select>
+                            </div>
+                        </div>
+                        <hr>
+                        <div class="monsterEditorSubsection">
+                            <div>
+                                <button id="customFeats" class="nonRollButton">Create Feat</button>
+                                <button id="importCustomFeat" class="nonRollButton">Import Feat</button>
+                            </div>
+                            <div class="deleteMonster">
+                                <div class="deleteMonster-header">
+                                    <label id="customFeatSelectLabel" for="customFeatSelect">Select Feat to Delete/Edit:</label>
+                                    <button id="deleteCustomFeats" class="nonRollButton">Delete Feat</button>
+                                    <button id="editCustomFeats" class="nonRollButton">Edit Feat</button>
+                                    <button id="exportCustomFeat" class="nonRollButton">Export Feat</button>
+                                </div>
+                                <select id="customFeatSelect"></select>
+                            </div>
+                        </div>
+                        <hr>
+                        <div class="monsterEditorSubsection">
+                            <div>
                                 <button id="customItems" class="nonRollButton">Create Item</button>
                                 <button id="importCustomItem" class="nonRollButton">Import Item</button>
                             </div>
@@ -1557,13 +1596,17 @@
                                 </div>
                                 <select id="givePlayerSelect"></select>
                                 <div class="give-row">
-                                    <input type="text" id="giveItemInput" list="giveItemOptions" placeholder="Item name...">
-                                    <datalist id="giveItemOptions"></datalist>
+                                    <div class="give-input-wrap">
+                                        <input type="text" id="giveItemInput" placeholder="Item name..." autocomplete="off">
+                                        <div id="giveItemDropdown" class="dropdown"></div>
+                                    </div>
                                     <button id="giveItemButton" class="nonRollButton">Give Item</button>
                                 </div>
                                 <div class="give-row">
-                                    <input type="text" id="giveSpellInput" list="giveSpellOptions" placeholder="Spell name...">
-                                    <datalist id="giveSpellOptions"></datalist>
+                                    <div class="give-input-wrap">
+                                        <input type="text" id="giveSpellInput" placeholder="Spell name..." autocomplete="off">
+                                        <div id="giveSpellDropdown" class="dropdown"></div>
+                                    </div>
                                     <button id="giveSpellButton" class="nonRollButton">Send Spell</button>
                                 </div>
                             </div>
@@ -1712,8 +1755,131 @@
             </form>
         </div>
     </div>
+
+    <!-- Homebrew race form -->
+    <div id="raceFormModal" style="display: none;">
+        <div class="spell-modal-background">
+            <span id="closeRaceForm" class="close">&times;</span>
+            <form id="raceForm" onsubmit="return false;">
+                <h2 id="raceFormTitle">Create a Race</h2>
+
+                <div class="form-row">
+                    <label id="raceNameLabel" for="raceFormName">Race Name:</label>
+                    <input type="text" id="raceFormName" placeholder="e.g., Aarakocra" required>
+                </div>
+                <div class="form-row">
+                    <label id="raceYearLabel" for="raceFormYear">Edition:</label>
+                    <select id="raceFormYear">
+                        <option value="2014">5e (2014)</option>
+                        <option value="2024">5.5e (2024)</option>
+                    </select>
+                </div>
+                <div class="form-row">
+                    <label id="raceSizeLabel" for="raceFormSize">Size:</label>
+                    <select id="raceFormSize">
+                        <option value="Medium">Medium</option>
+                        <option value="Small">Small</option>
+                        <option value="Small or Medium">Small or Medium</option>
+                        <option value="Large">Large</option>
+                    </select>
+                </div>
+                <div class="form-row">
+                    <label id="raceSpeedLabel" for="raceFormSpeed">Walking Speed (ft):</label>
+                    <input type="number" id="raceFormSpeed" min="0" max="120" value="30">
+                </div>
+                <div class="form-row">
+                    <label id="raceLanguagesLabel" for="raceFormLanguages">Languages:</label>
+                    <input type="text" id="raceFormLanguages" placeholder="Common, Elvish">
+                </div>
+
+                <label class="homebrew-subhead">Ability Score Increases</label>
+                <p class="homebrew-hint">Each row adds a fixed bonus (e.g. +2 Dexterity, +1 Wisdom).</p>
+                <div id="raceAbilityRows"></div>
+                <button id="addRaceAbility" class="nonRollButton" type="button">+ Add Ability Increase</button>
+
+                <label class="homebrew-subhead">Traits</label>
+                <div id="raceTraitRows"></div>
+                <button id="addRaceTrait" class="nonRollButton" type="button">+ Add Trait</button>
+
+                <div class="form-row">
+                    <label id="raceSkillsLabel" for="raceFormSkills">Skill Proficiencies:</label>
+                    <input type="text" id="raceFormSkills" placeholder="Perception, Stealth">
+                </div>
+                <div class="form-row">
+                    <label id="raceWeaponsLabel" for="raceFormWeapons">Weapon Proficiencies:</label>
+                    <input type="text" id="raceFormWeapons" placeholder="Longsword, Shortbow">
+                </div>
+                <div class="form-row">
+                    <label id="raceArmorLabel" for="raceFormArmor">Armor Proficiencies:</label>
+                    <input type="text" id="raceFormArmor" placeholder="Light armor">
+                </div>
+                <div class="form-row">
+                    <label id="raceToolsLabel" for="raceFormTools">Tool Proficiencies:</label>
+                    <input type="text" id="raceFormTools" placeholder="Smith's tools">
+                </div>
+                <div class="form-row">
+                    <label id="raceSpellsLabel" for="raceFormSpells">Spells Granted:</label>
+                    <input type="text" id="raceFormSpells" placeholder="Dancing Lights, Faerie Fire">
+                </div>
+
+                <div id="raceValidation"></div>
+                <button id="saveRace" class="nonRollButton" type="button">Save Race</button>
+            </form>
+        </div>
+    </div>
+
+    <!-- Homebrew feat form -->
+    <div id="featFormModal" style="display: none;">
+        <div class="spell-modal-background">
+            <span id="closeFeatForm" class="close">&times;</span>
+            <form id="featForm" onsubmit="return false;">
+                <h2 id="featFormTitle">Create a Feat</h2>
+
+                <div class="form-row">
+                    <label id="featNameLabel" for="featFormName">Feat Name:</label>
+                    <input type="text" id="featFormName" placeholder="e.g., Alert" required>
+                </div>
+                <div class="form-row">
+                    <label id="featYearLabel" for="featFormYear">Edition:</label>
+                    <select id="featFormYear">
+                        <option value="2014">5e (2014)</option>
+                        <option value="2024">5.5e (2024)</option>
+                    </select>
+                </div>
+                <div class="form-row">
+                    <label id="featPrereqLabel" for="featFormPrereq">Prerequisite:</label>
+                    <input type="text" id="featFormPrereq" placeholder="e.g., Dexterity 13 or higher (blank if none)">
+                </div>
+                <div class="form-row">
+                    <label id="featDescLabel" for="featFormDesc">Description:</label>
+                    <textarea id="featFormDesc" rows="5" placeholder="One paragraph per line. Start a line with • for a bullet point."></textarea>
+                </div>
+                <div class="form-row">
+                    <label id="featMultipleLabel" for="featFormMultiple">Can be taken more than once:</label>
+                    <input type="checkbox" id="featFormMultiple">
+                </div>
+
+                <label class="homebrew-subhead">Ability Score Increase</label>
+                <p class="homebrew-hint">Add one ability for a fixed +N. Add several to let the player choose one of them (half-feat style).</p>
+                <div id="featAbilityRows"></div>
+                <button id="addFeatAbility" class="nonRollButton" type="button">+ Add Ability Option</button>
+
+                <div class="form-row">
+                    <label id="featSpellsLabel" for="featFormSpells">Spells Granted:</label>
+                    <input type="text" id="featFormSpells" placeholder="Misty Step">
+                </div>
+                <div class="form-row">
+                    <label id="featProfsLabel" for="featFormProfs">Proficiencies Granted:</label>
+                    <input type="text" id="featFormProfs" placeholder="One skill of choice, Firearms">
+                </div>
+
+                <div id="featValidation"></div>
+                <button id="saveFeat" class="nonRollButton" type="button">Save Feat</button>
+            </form>
+        </div>
+    </div>
     <script>
-        
+
 
     </script>
     <footer>

--- a/DMScript.js
+++ b/DMScript.js
@@ -869,6 +869,7 @@ function populateMonsterFields(monster) {
     checkAndPopulateSection('monsterSkills', monster.Skills, 'skill');
     checkAndPopulateSection('monsterSaves', monster.Saves, 'savingThrow');
     checkAndPopulateSection('monsterActions', monster.Actions, 'action');
+    checkAndPopulateSection('monsterBonusActions', monster.BonusActions, 'action');
     checkAndPopulateSection('monsterReactions', monster.Reactions, 'action');
     checkAndPopulateSection('monsterAbilities', monster.Traits, 'traits');
     checkAndPopulateSection('monsterLegendaryActions', monster.LegendaryActions, 'legendaryAction');
@@ -2541,6 +2542,7 @@ document.getElementById("monsterCreationForm").addEventListener("submit", functi
         QuickAction: collectDynamicFields("monsterFormQuickActions"),
         Traits: collectDynamicFields("monsterFormTraits"),
         Actions: collectDynamicFields("monsterFormActions"),
+        BonusActions: collectDynamicFields("monsterFormBonusActions"),
         Reactions: collectDynamicFields("monsterFormReactions"),
         LegendaryActions: collectDynamicFields("monsterFormLegendaryActions")
     };
@@ -2667,6 +2669,7 @@ function populateDynamicFields(sectionId, data) {
 // Buttons to add dynamic entries
 document.getElementById("addTraitButton").addEventListener("click", () => addDynamicField("monsterFormTraits"));
 document.getElementById("addActionButton").addEventListener("click", () => addDynamicField("monsterFormActions"));
+document.getElementById("addBonusActionButton").addEventListener("click", () => addDynamicField("monsterFormBonusActions"));
 document.getElementById("addReactionButton").addEventListener("click", () => addDynamicField("monsterFormReactions"));
 document.getElementById("addLegendaryActionsButton").addEventListener("click", () => addDynamicField("monsterFormLegendaryActions"));
 
@@ -2897,6 +2900,7 @@ function populateMonsterForm(monster) {
 
     populateDynamicFields("monsterFormTraits", monster.Traits);
     populateDynamicFields("monsterFormActions", monster.Actions);
+    populateDynamicFields("monsterFormBonusActions", monster.BonusActions);
     populateDynamicFields("monsterFormReactions", monster.Reactions);
     populateDynamicFields("monsterFormLegendaryActions", monster.LegendaryActions);
     populateDynamicFields("monsterFormQuickActions", monster.QuickAction);
@@ -4714,7 +4718,7 @@ function getGiveEquipmentCatalog() {
     return info?.equipmentData || [];
 }
 
-function populateGiveToPlayerSection() {
+async function populateGiveToPlayerSection() {
     const playerSelect = document.getElementById('givePlayerSelect');
     if (!playerSelect) return;
 
@@ -4735,23 +4739,81 @@ function populateGiveToPlayerSection() {
         });
     }
 
-    const itemOptions = document.getElementById('giveItemOptions');
-    itemOptions.innerHTML = '';
-    getGiveEquipmentCatalog().forEach(item => {
-        if (!item?.name) return;
-        const option = document.createElement('option');
-        option.value = item.name;
-        itemOptions.appendChild(option);
-    });
+    // The item/spell autocompletes read these catalogs live when the field is
+    // focused, so make sure they're loaded before the DM starts typing.
+    if (!AppData.equipmentLookupInfo) await loadEquipmentDataFiles();
+    if (!AppData.spellLookupInfo) await loadSpellDataFiles();
+}
 
-    const spellOptions = document.getElementById('giveSpellOptions');
-    spellOptions.innerHTML = '';
-    (AppData.spellLookupInfo?.spellsData || []).forEach(spell => {
-        if (!spell?.name) return;
-        const option = document.createElement('option');
-        option.value = spell.name;
-        spellOptions.appendChild(option);
-    });
+// TaleSpire's webview doesn't render native <datalist> popups, so the give-to-
+// player fields use the same hand-rolled dropdown as the shop/monster/player
+// lists. getNames() is read live so newly-created homebrew shows up right away.
+function setupGiveDropdown(inputId, dropdownId, getNames) {
+    const input = document.getElementById(inputId);
+    const dropdown = document.getElementById(dropdownId);
+    if (!input || !dropdown) return;
+
+    function render() {
+        const search = input.value.trim().toLowerCase();
+        dropdown.innerHTML = '';
+        getNames()
+            .filter(name => name.toLowerCase().includes(search))
+            .slice(0, 100) // catalogs run to the hundreds; cap the visible list
+            .forEach(name => {
+                const option = document.createElement('div');
+                option.classList.add('dropdown-item');
+                option.textContent = name;
+                // mousedown fires before the input's blur, so the pick registers
+                option.addEventListener('mousedown', () => {
+                    input.value = name;
+                    dropdown.style.display = 'none';
+                    updateGiveDropdownSpace();
+                });
+                dropdown.appendChild(option);
+            });
+        dropdown.style.display = dropdown.childElementCount ? 'block' : 'none';
+        updateGiveDropdownSpace();
+    }
+
+    input.addEventListener('focus', render);
+    input.addEventListener('input', render);
+    input.addEventListener('blur', () => setTimeout(() => {
+        dropdown.style.display = 'none';
+        updateGiveDropdownSpace();
+    }, 200));
+}
+
+// An open autocomplete is absolutely positioned, so on its own it doesn't grow
+// the panel — it just spills past the bottom of the modal and off-screen. Reserve
+// exactly enough space below the content for the open list (plus a little
+// padding); the panel's height:auto then expands to contain it, and if the panel
+// is already capped at max-height we scroll the list into view instead.
+function updateGiveDropdownSpace() {
+    const modalContent = document.querySelector('.homebrew-modal-content');
+    if (!modalContent) return;
+    const scroller = document.querySelector('.homebrew-modal-background');
+
+    const open = ['giveItemDropdown', 'giveSpellDropdown']
+        .map(id => document.getElementById(id))
+        .filter(dd => dd && dd.style.display === 'block');
+
+    // Clear any prior reservation so we measure the natural content bottom
+    modalContent.style.paddingBottom = '';
+    if (open.length === 0) return;
+
+    const contentBottom = modalContent.getBoundingClientRect().bottom;
+    const listBottom = Math.max(...open.map(dd => dd.getBoundingClientRect().bottom));
+    const overhang = listBottom - contentBottom;
+    if (overhang > 0) modalContent.style.paddingBottom = (overhang + 24) + 'px';
+
+    // If the panel is capped at its max height, reveal the reserved space
+    if (scroller) {
+        const scRect = scroller.getBoundingClientRect();
+        const listBottomNow = Math.max(...open.map(dd => dd.getBoundingClientRect().bottom));
+        if (listBottomNow > scRect.bottom) {
+            scroller.scrollTop += (listBottomNow - scRect.bottom) + 12;
+        }
+    }
 }
 
 async function sendGiveMessage(type, payload, playerId, successText, button) {
@@ -4785,6 +4847,12 @@ async function sendGiveMessage(type, payload, playerId, successText, button) {
 if (document.getElementById('giveToPlayerSection')) {
     // Refresh the player list and name suggestions whenever homebrew opens
     document.getElementById('openHomebrew').addEventListener('click', populateGiveToPlayerSection);
+
+    // Autocomplete dropdowns for the item/spell fields (read the catalogs live)
+    setupGiveDropdown('giveItemInput', 'giveItemDropdown',
+        () => getGiveEquipmentCatalog().map(i => i && i.name).filter(Boolean));
+    setupGiveDropdown('giveSpellInput', 'giveSpellDropdown',
+        () => (AppData.spellLookupInfo?.spellsData || []).map(s => s && s.name).filter(Boolean));
 
     document.getElementById('giveItemButton').addEventListener('click', () => {
         const playerSelect = document.getElementById('givePlayerSelect');

--- a/PlayerCharacter.html
+++ b/PlayerCharacter.html
@@ -1559,6 +1559,38 @@
                     <hr>
                     <div class="monsterEditorSubsection">
                         <div>
+                            <button id="customRaces" class="nonRollButton">Create Race</button>
+                            <button id="importCustomRace" class="nonRollButton">Import Race</button>
+                        </div>
+                        <div class="deleteMonster">
+                            <div class="deleteMonster-header">
+                                <label id="customRaceSelectLabel" for="customRaceSelect">Select Race to Delete/Edit:</label>
+                                <button id="deleteCustomRaces" class="nonRollButton">Delete Race</button>
+                                <button id="editCustomRaces" class="nonRollButton">Edit Race</button>
+                                <button id="exportCustomRace" class="nonRollButton">Export Race</button>
+                            </div>
+                            <select id="customRaceSelect"></select>
+                        </div>
+                    </div>
+                    <hr>
+                    <div class="monsterEditorSubsection">
+                        <div>
+                            <button id="customFeats" class="nonRollButton">Create Feat</button>
+                            <button id="importCustomFeat" class="nonRollButton">Import Feat</button>
+                        </div>
+                        <div class="deleteMonster">
+                            <div class="deleteMonster-header">
+                                <label id="customFeatSelectLabel" for="customFeatSelect">Select Feat to Delete/Edit:</label>
+                                <button id="deleteCustomFeats" class="nonRollButton">Delete Feat</button>
+                                <button id="editCustomFeats" class="nonRollButton">Edit Feat</button>
+                                <button id="exportCustomFeat" class="nonRollButton">Export Feat</button>
+                            </div>
+                            <select id="customFeatSelect"></select>
+                        </div>
+                    </div>
+                    <hr>
+                    <div class="monsterEditorSubsection">
+                        <div>
                             <button id="customItems" class="nonRollButton">Create Item</button>
                             <button id="importCustomItem" class="nonRollButton">Import Item</button>
                         </div>
@@ -1705,6 +1737,129 @@
             <div id="subclassValidation"></div>
 
             <button id="saveSubclass" class="nonRollButton" type="button">Save Subclass</button>
+        </form>
+    </div>
+</div>
+
+<!-- Homebrew race form -->
+<div id="raceFormModal" style="display: none;">
+    <div class="spell-modal-background">
+        <span id="closeRaceForm" class="close">&times;</span>
+        <form id="raceForm" onsubmit="return false;">
+            <h2 id="raceFormTitle">Create a Race</h2>
+
+            <div class="form-row">
+                <label id="raceNameLabel" for="raceFormName">Race Name:</label>
+                <input type="text" id="raceFormName" placeholder="e.g., Aarakocra" required>
+            </div>
+            <div class="form-row">
+                <label id="raceYearLabel" for="raceFormYear">Edition:</label>
+                <select id="raceFormYear">
+                    <option value="2014">5e (2014)</option>
+                    <option value="2024">5.5e (2024)</option>
+                </select>
+            </div>
+            <div class="form-row">
+                <label id="raceSizeLabel" for="raceFormSize">Size:</label>
+                <select id="raceFormSize">
+                    <option value="Medium">Medium</option>
+                    <option value="Small">Small</option>
+                    <option value="Small or Medium">Small or Medium</option>
+                    <option value="Large">Large</option>
+                </select>
+            </div>
+            <div class="form-row">
+                <label id="raceSpeedLabel" for="raceFormSpeed">Walking Speed (ft):</label>
+                <input type="number" id="raceFormSpeed" min="0" max="120" value="30">
+            </div>
+            <div class="form-row">
+                <label id="raceLanguagesLabel" for="raceFormLanguages">Languages:</label>
+                <input type="text" id="raceFormLanguages" placeholder="Common, Elvish">
+            </div>
+
+            <label class="homebrew-subhead">Ability Score Increases</label>
+            <p class="homebrew-hint">Each row adds a fixed bonus (e.g. +2 Dexterity, +1 Wisdom).</p>
+            <div id="raceAbilityRows"></div>
+            <button id="addRaceAbility" class="nonRollButton" type="button">+ Add Ability Increase</button>
+
+            <label class="homebrew-subhead">Traits</label>
+            <div id="raceTraitRows"></div>
+            <button id="addRaceTrait" class="nonRollButton" type="button">+ Add Trait</button>
+
+            <div class="form-row">
+                <label id="raceSkillsLabel" for="raceFormSkills">Skill Proficiencies:</label>
+                <input type="text" id="raceFormSkills" placeholder="Perception, Stealth">
+            </div>
+            <div class="form-row">
+                <label id="raceWeaponsLabel" for="raceFormWeapons">Weapon Proficiencies:</label>
+                <input type="text" id="raceFormWeapons" placeholder="Longsword, Shortbow">
+            </div>
+            <div class="form-row">
+                <label id="raceArmorLabel" for="raceFormArmor">Armor Proficiencies:</label>
+                <input type="text" id="raceFormArmor" placeholder="Light armor">
+            </div>
+            <div class="form-row">
+                <label id="raceToolsLabel" for="raceFormTools">Tool Proficiencies:</label>
+                <input type="text" id="raceFormTools" placeholder="Smith's tools">
+            </div>
+            <div class="form-row">
+                <label id="raceSpellsLabel" for="raceFormSpells">Spells Granted:</label>
+                <input type="text" id="raceFormSpells" placeholder="Dancing Lights, Faerie Fire">
+            </div>
+
+            <div id="raceValidation"></div>
+            <button id="saveRace" class="nonRollButton" type="button">Save Race</button>
+        </form>
+    </div>
+</div>
+
+<!-- Homebrew feat form -->
+<div id="featFormModal" style="display: none;">
+    <div class="spell-modal-background">
+        <span id="closeFeatForm" class="close">&times;</span>
+        <form id="featForm" onsubmit="return false;">
+            <h2 id="featFormTitle">Create a Feat</h2>
+
+            <div class="form-row">
+                <label id="featNameLabel" for="featFormName">Feat Name:</label>
+                <input type="text" id="featFormName" placeholder="e.g., Alert" required>
+            </div>
+            <div class="form-row">
+                <label id="featYearLabel" for="featFormYear">Edition:</label>
+                <select id="featFormYear">
+                    <option value="2014">5e (2014)</option>
+                    <option value="2024">5.5e (2024)</option>
+                </select>
+            </div>
+            <div class="form-row">
+                <label id="featPrereqLabel" for="featFormPrereq">Prerequisite:</label>
+                <input type="text" id="featFormPrereq" placeholder="e.g., Dexterity 13 or higher (blank if none)">
+            </div>
+            <div class="form-row">
+                <label id="featDescLabel" for="featFormDesc">Description:</label>
+                <textarea id="featFormDesc" rows="5" placeholder="One paragraph per line. Start a line with • for a bullet point."></textarea>
+            </div>
+            <div class="form-row">
+                <label id="featMultipleLabel" for="featFormMultiple">Can be taken more than once:</label>
+                <input type="checkbox" id="featFormMultiple">
+            </div>
+
+            <label class="homebrew-subhead">Ability Score Increase</label>
+            <p class="homebrew-hint">Add one ability for a fixed +N. Add several to let the player choose one of them (half-feat style).</p>
+            <div id="featAbilityRows"></div>
+            <button id="addFeatAbility" class="nonRollButton" type="button">+ Add Ability Option</button>
+
+            <div class="form-row">
+                <label id="featSpellsLabel" for="featFormSpells">Spells Granted:</label>
+                <input type="text" id="featFormSpells" placeholder="Misty Step">
+            </div>
+            <div class="form-row">
+                <label id="featProfsLabel" for="featFormProfs">Proficiencies Granted:</label>
+                <input type="text" id="featFormProfs" placeholder="One skill of choice, Firearms">
+            </div>
+
+            <div id="featValidation"></div>
+            <button id="saveFeat" class="nonRollButton" type="button">Save Feat</button>
         </form>
     </div>
 </div>

--- a/PlayerScript.js
+++ b/PlayerScript.js
@@ -8122,6 +8122,20 @@ document.getElementById("importSaveButton").addEventListener("click", async () =
                 return;
             }
             saveToGlobalStorage(importDataType, key, dataInfo, true);
+        } else if (importDataType === "Custom Races") {
+            const result = await validateCustomRace(dataInfo || {});
+            if (result.errors.length > 0) {
+                showErrorModal("Race failed verification: " + result.errors.join(' '));
+                return;
+            }
+            saveToGlobalStorage(importDataType, key, dataInfo, true);
+        } else if (importDataType === "Custom Feats") {
+            const result = await validateCustomFeat(dataInfo || {});
+            if (result.errors.length > 0) {
+                showErrorModal("Feat failed verification: " + result.errors.join(' '));
+                return;
+            }
+            saveToGlobalStorage(importDataType, key, dataInfo, true);
         } else if (importDataType === "Custom Spells" || importDataType === "Custom Equipment") {
             saveToGlobalStorage(importDataType, key, dataInfo, true);
         } else {

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ If you want traditional written guides instead of the video, start here:
 - [DM Screen Guide](docs/README_DM_SCREEN.md)
 - [Player Character Sheet Guide](docs/README_PLAYER_CHARACTER_SHEET.md)
 - [Homebrew, Imports, and Exports Guide](docs/README_HOMEBREW_AND_IMPORTS.md)
+- [Local Content Guide](docs/README_LOCAL_CONTENT.md) — load DM-provided spells, races, classes, and subclasses from a gitignored `local-content/` folder
 
 ## What The Toolset Includes
 

--- a/SharedScript.js
+++ b/SharedScript.js
@@ -1275,17 +1275,20 @@ const translations = {
         quickActionsLegend: "Quick Actions",
         traitsLegend: "Traits",
         actionsLegend: "Actions",
+        bonusActionsLegend: "Bonus Actions",
         reactionsLegend: "Reactions",
         legendaryActionsLegend: "Legendary Actions",
         saveMonsterButton: "Save Monster",
         addTraitButton: "Add Trait",
         addActionButton: "Add Action",
+        addBonusActionButton: "Add Bonus Action",
         addReactionButton: "Add Reaction",
         addLegendaryActionsButton: "Add Legendary Actions",
 
         dynamicSections: {
             monsterFormTraits: "Traits",
             monsterFormActions: "Actions",
+            monsterFormBonusActions: "Bonus Actions",
             monsterFormReactions: "Reactions",
             monsterFormLegendaryActions: "Legendary Actions",
             monsterFormQuickActions: "Quick Actions"
@@ -2461,17 +2464,20 @@ const translations = {
         quickActionsLegend: "Acciones Rápidas",
         traitsLegend: "Rasgos",
         actionsLegend: "Acciones",
+        bonusActionsLegend: "Acciones Adicionales",
         reactionsLegend: "Reacciones",
         legendaryActionsLegend: "Acciones Legendarias",
         saveMonsterButton: "Guardar Monstruo",
         addTraitButton: "Agregar Rasgo",
         addActionButton: "Agregar Acción",
+        addBonusActionButton: "Agregar Acción Adicional",
         addReactionButton: "Agregar Reacción",
         addLegendaryActionsButton: "Agregar Acciones Legendarias",
 
         dynamicSections: {
             monsterFormTraits: "Rasgos",
             monsterFormActions: "Acciones",
+            monsterFormBonusActions: "Acciones Adicionales",
             monsterFormReactions: "Reacciones",
             monsterFormLegendaryActions: "Acciones Legendarias",
             monsterFormQuickActions: "Acciones Rápidas"
@@ -4189,6 +4195,20 @@ function removeFromCampaignStorage(dataType, dataId) {
 
 
 
+// Fetches an optional DM-provided JSON file from the gitignored local-content/
+// folder (see docs/README_LOCAL_CONTENT.md). Returns null when the file is
+// absent or unparseable so callers can fall through to shipped data only.
+async function loadLocalContentJson(path) {
+    try {
+        const response = await fetch(path);
+        if (!response.ok) return null;
+        return await response.json();
+    } catch (error) {
+        console.warn(`Local content file ${path} not loaded:`, error);
+        return null;
+    }
+}
+
 // read the JSON file spells.json and save the data and names to variables
 async function readSpellJson() {
     try {
@@ -4199,17 +4219,31 @@ async function readSpellJson() {
         if (!response.ok) throw new Error('Network response was not ok');
         const spellsData = await response.json();
 
-        let combinedData = isGlobalDataAnObject 
+        // Optional DM-provided spells: same shape as spells-eng.json entries.
+        // A local spell with the same name and year replaces the shipped one.
+        const localSpells = (await loadLocalContentJson('local-content/spells.json')) || [];
+        const localSpellKeys = new Set(localSpells.map(s => `${(s.name || '').toLowerCase()}|${s.year || '2014'}`));
+        const officialSpells = localSpellKeys.size
+            ? spellsData.filter(s => !localSpellKeys.has(`${(s.name || '').toLowerCase()}|${s.year || '2014'}`))
+            : spellsData;
+
+        // The DM's own homebrew (Custom Spells) should always be available
+        // regardless of the 2014/2024 edition toggle — only the official and
+        // local-content catalogs get edition-filtered. Otherwise a homebrew
+        // spell tagged for one edition silently disappears (from spell lists
+        // AND the "give spell" picker) whenever the campaign is set to the
+        // other edition.
+        const customSpells = isGlobalDataAnObject
             ? Object.values(allSpellData)
-            : allSpellData;
-        
-        combinedData = [...combinedData, ...spellsData];
+            : (allSpellData || []);
+
+        const officialCatalog = [...officialSpells, ...localSpells];
 
         const versionData = await loadDataFromGlobalStorage("D&DVersion");
         const versionSetting = versionData?.Version || '2014';
-        
-        // Add version filtering
-        let filteredData = combinedData.filter(spell => {
+
+        // Edition filtering applies to the official/local catalog only
+        let filteredOfficial = officialCatalog.filter(spell => {
             const spellYear = spell.year || '2014';
             if (versionSetting === 'both') return true;
             return spellYear === versionSetting;
@@ -4219,24 +4253,27 @@ async function readSpellJson() {
         if (versionSetting === 'both') {
             // Create a map to track spell name occurrences
             const spellCountMap = {};
-            
-            filteredData = filteredData.map(spell => {
+
+            filteredOfficial = filteredOfficial.map(spell => {
                 // Create a copy of the spell object to avoid mutation
                 const modifiedSpell = {...spell};
-                
+
                 const year = modifiedSpell.year || '2014';
                 const symbol = year === '2014' ? '' : ' 🜁';
-                
+
                 // Count occurrences to handle duplicates
                 const count = spellCountMap[modifiedSpell.name] || 0;
                 spellCountMap[modifiedSpell.name] = count + 1;
-                
+
                 // Append symbol to the spell name
                 modifiedSpell.name += symbol;
-                
+
                 return modifiedSpell;
             });
         }
+
+        // Homebrew first, then the edition-filtered official catalog
+        const filteredData = [...customSpells, ...filteredOfficial];
 
         // Extract spell names from the modified/filtered data
         const spellNames = filteredData.map(spell => spell.name);
@@ -6549,6 +6586,8 @@ async function getSpellNameIndex() {
     } catch (error) {
         console.error("Could not load spell catalog for verification:", error);
     }
+    const localSpells = await loadLocalContentJson('local-content/spells.json');
+    (localSpells || []).forEach(spell => { if (spell.name) names.add(spell.name.toLowerCase()); });
     try {
         const customSpells = await loadDataFromGlobalStorage("Custom Spells");
         Object.keys(customSpells || {}).forEach(name => names.add(name.toLowerCase()));
@@ -6576,6 +6615,14 @@ async function getBuiltInSubclassIndex() {
         console.error("Could not load built-in subclass list:", error);
         builtInSubclassIndex = {};
     }
+    // DM-provided subclasses count as built-in for homebrew collision checks
+    const localSubclasses = await loadLocalContentJson('local-content/subclasses.json');
+    Object.entries(localSubclasses || {}).forEach(([classKey, subs]) => {
+        builtInSubclassIndex[classKey] = builtInSubclassIndex[classKey] || [];
+        Object.keys(subs || {}).forEach(name => {
+            if (!builtInSubclassIndex[classKey].includes(name)) builtInSubclassIndex[classKey].push(name);
+        });
+    });
     return builtInSubclassIndex;
 }
 
@@ -7178,6 +7225,18 @@ if (!document.getElementById('importCharacterData') && document.getElementById('
                     showErrorModal("Subclass failed verification: " + result.errors.join(' '));
                     return;
                 }
+            } else if (importDataType === "Custom Races") {
+                const result = await validateCustomRace(dataInfo || {});
+                if (result.errors.length > 0) {
+                    showErrorModal("Race failed verification: " + result.errors.join(' '));
+                    return;
+                }
+            } else if (importDataType === "Custom Feats") {
+                const result = await validateCustomFeat(dataInfo || {});
+                if (result.errors.length > 0) {
+                    showErrorModal("Feat failed verification: " + result.errors.join(' '));
+                    return;
+                }
             } else if (importDataType !== "Custom Spells" && importDataType !== "Custom Equipment") {
                 showErrorModal("Invalid dataType. Please check the format and try again.");
                 return;
@@ -7191,6 +7250,599 @@ if (!document.getElementById('importCharacterData') && document.getElementById('
             console.error("Failed to import data:", error);
             showErrorModal("Invalid data. Please check the format and try again.");
         }
+    });
+}
+
+
+// ============================================================================
+// Homebrew races & feats
+// ----------------------------------------------------------------------------
+// Custom races live in global storage under "Custom Races" (keyed by name) and
+// custom feats under "Custom Feats". They mirror the built-in Races.json /
+// Feats.json shapes so the Character Creator can merge them in and treat them
+// like official content. Create / edit / delete / import / export work exactly
+// like Custom Subclasses and Custom Spells.
+// ============================================================================
+
+const HOMEBREW_ABILITY_OPTIONS = [
+    ['strength', 'STR', 'Strength'], ['dexterity', 'DEX', 'Dexterity'],
+    ['constitution', 'CON', 'Constitution'], ['intelligence', 'INT', 'Intelligence'],
+    ['wisdom', 'WIS', 'Wisdom'], ['charisma', 'CHA', 'Charisma']
+];
+
+function homebrewSlug(name) {
+    return (name || '').toString().toLowerCase().normalize('NFKD')
+        .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+// Built-in names, loaded once, so homebrew can be checked for collisions.
+let builtInRaceIndex = null;
+async function getBuiltInRaceIndex() {
+    if (builtInRaceIndex) return builtInRaceIndex;
+    const names = new Set();
+    try {
+        const response = await fetch('CharacterCreator/Races.json');
+        if (response.ok) {
+            const data = await response.json();
+            Object.values(data || {}).forEach(r => { if (r && r.name) names.add(r.name.toLowerCase()); });
+        }
+    } catch (error) {
+        console.error("Could not load built-in race list:", error);
+    }
+    const localRaces = await loadLocalContentJson('local-content/races.json');
+    Object.values(localRaces || {}).forEach(r => { if (r && r.name) names.add(r.name.toLowerCase()); });
+    builtInRaceIndex = names;
+    return names;
+}
+
+let builtInFeatIndex = null;
+async function getBuiltInFeatIndex() {
+    if (builtInFeatIndex) return builtInFeatIndex;
+    const names = new Set();
+    try {
+        const response = await fetch('CharacterCreator/Feats.json');
+        if (response.ok) {
+            const data = await response.json();
+            (data.feats || []).forEach(f => { if (f && f.name) names.add(f.name.toLowerCase()); });
+        }
+    } catch (error) {
+        console.error("Could not load built-in feat list:", error);
+    }
+    const localFeats = await loadLocalContentJson('local-content/feats.json');
+    (localFeats || []).forEach(f => { if (f && f.name) names.add(f.name.toLowerCase()); });
+    builtInFeatIndex = names;
+    return names;
+}
+
+// --- Shared form widgets ----------------------------------------------------
+
+function makeHomebrewAbilitySelect(selectedCode) {
+    const select = document.createElement('select');
+    select.className = 'homebrew-ability-select';
+    HOMEBREW_ABILITY_OPTIONS.forEach(([, code, label]) => {
+        const option = new Option(label, code);
+        if (code === selectedCode) option.selected = true;
+        select.appendChild(option);
+    });
+    return select;
+}
+
+/** One ability-score row: ability picker + amount. Used by race and feat forms. */
+function addHomebrewAbilityRow(containerId, code = 'STR', value = 1, onChange) {
+    const rows = document.getElementById(containerId);
+    const row = document.createElement('div');
+    row.className = 'homebrew-ability-row';
+
+    const select = makeHomebrewAbilitySelect(code);
+    const plus = document.createElement('span');
+    plus.className = 'homebrew-ability-plus';
+    plus.textContent = '+';
+    const amount = document.createElement('input');
+    amount.type = 'number';
+    amount.min = '1';
+    amount.max = '5';
+    amount.value = value;
+    amount.className = 'homebrew-ability-value';
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.className = 'nonRollButton subclass-feature-remove';
+    removeButton.textContent = '✖';
+    removeButton.addEventListener('click', () => { row.remove(); if (onChange) onChange(); });
+
+    [select, amount].forEach(el => el.addEventListener('input', () => { if (onChange) onChange(); }));
+
+    row.appendChild(select);
+    row.appendChild(plus);
+    row.appendChild(amount);
+    row.appendChild(removeButton);
+    rows.appendChild(row);
+}
+
+function showHomebrewValidation(boxId, errors, warnings) {
+    const box = document.getElementById(boxId);
+    if (!box) return;
+    box.innerHTML = '';
+    errors.forEach(text => {
+        const p = document.createElement('p');
+        p.className = 'subclass-validation-error';
+        p.textContent = '✖ ' + text;
+        box.appendChild(p);
+    });
+    warnings.forEach(text => {
+        const p = document.createElement('p');
+        p.className = 'subclass-validation-warning';
+        p.textContent = '⚠ ' + text;
+        box.appendChild(p);
+    });
+}
+
+function homebrewCsv(id) {
+    return document.getElementById(id).value.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+// ============================================================================
+// Custom races
+// ============================================================================
+
+function clearRaceValidation() {
+    const box = document.getElementById('raceValidation');
+    if (box) box.innerHTML = '';
+    const button = document.getElementById('saveRace');
+    if (button) { button.dataset.warningsConfirmed = ''; button.textContent = 'Save Race'; }
+}
+
+/** One race trait: name + description (same layout as a subclass feature). */
+function addRaceTraitRow(name = '', description = '') {
+    const rows = document.getElementById('raceTraitRows');
+    const row = document.createElement('div');
+    row.className = 'subclass-feature-row';
+
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.className = 'race-trait-name';
+    nameInput.placeholder = 'Trait name';
+    nameInput.value = name;
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.className = 'nonRollButton subclass-feature-remove';
+    removeButton.textContent = '✖';
+    removeButton.addEventListener('click', () => { row.remove(); clearRaceValidation(); });
+
+    const descInput = document.createElement('textarea');
+    descInput.rows = 2;
+    descInput.className = 'race-trait-desc';
+    descInput.placeholder = 'What the trait does';
+    descInput.value = description;
+
+    [nameInput, descInput].forEach(el => el.addEventListener('input', clearRaceValidation));
+
+    const topLine = document.createElement('div');
+    topLine.className = 'subclass-feature-row-top';
+    topLine.appendChild(nameInput);
+    topLine.appendChild(removeButton);
+
+    row.appendChild(topLine);
+    row.appendChild(descInput);
+    rows.appendChild(row);
+}
+
+function resetRaceForm() {
+    document.getElementById('raceFormTitle').textContent = 'Create a Race';
+    document.getElementById('raceFormName').value = '';
+    document.getElementById('raceFormYear').selectedIndex = 0;
+    document.getElementById('raceFormSize').value = 'Medium';
+    document.getElementById('raceFormSpeed').value = '30';
+    ['raceFormLanguages', 'raceFormSkills', 'raceFormWeapons', 'raceFormArmor',
+     'raceFormTools', 'raceFormSpells'].forEach(id => { document.getElementById(id).value = ''; });
+    document.getElementById('raceAbilityRows').innerHTML = '';
+    document.getElementById('raceTraitRows').innerHTML = '';
+    addRaceTraitRow();
+    clearRaceValidation();
+}
+
+function populateRaceForm(race) {
+    document.getElementById('raceFormTitle').textContent = 'Edit Race';
+    document.getElementById('raceFormName').value = race.name || '';
+    document.getElementById('raceFormYear').value = race.year === '2024' ? '2024' : '2014';
+    document.getElementById('raceFormSize').value = race.size || 'Medium';
+    document.getElementById('raceFormSpeed').value = race.speed || 30;
+    document.getElementById('raceFormLanguages').value = (race.languages || []).join(', ');
+    document.getElementById('raceFormSkills').value = (race.skillProficiencies || []).join(', ');
+    document.getElementById('raceFormWeapons').value = (race.weaponProficiencies || []).join(', ');
+    document.getElementById('raceFormArmor').value = (race.armorProficiencies || []).join(', ');
+    document.getElementById('raceFormTools').value = (race.toolProficiencies || []).join(', ');
+    document.getElementById('raceFormSpells').value = (race.spellsGranted || []).join(', ');
+
+    const abilityRows = document.getElementById('raceAbilityRows');
+    abilityRows.innerHTML = '';
+    Object.entries(race.abilityScoreIncrease || {}).forEach(([full, value]) => {
+        const opt = HOMEBREW_ABILITY_OPTIONS.find(a => a[0] === full);
+        addHomebrewAbilityRow('raceAbilityRows', opt ? opt[1] : 'STR', value, clearRaceValidation);
+    });
+
+    const traitRows = document.getElementById('raceTraitRows');
+    traitRows.innerHTML = '';
+    (race.traits || []).forEach(t => addRaceTraitRow(t.name, t.description));
+    if (!traitRows.children.length) addRaceTraitRow();
+
+    clearRaceValidation();
+}
+
+function collectRaceFromForm() {
+    const name = document.getElementById('raceFormName').value.trim();
+
+    const abilityScoreIncrease = {};
+    const bonuses = [];
+    document.querySelectorAll('#raceAbilityRows .homebrew-ability-row').forEach(row => {
+        const code = row.querySelector('.homebrew-ability-select').value;
+        const value = parseInt(row.querySelector('.homebrew-ability-value').value, 10);
+        if (!code || !value) return;
+        const full = (HOMEBREW_ABILITY_OPTIONS.find(a => a[1] === code) || [])[0];
+        if (!full) return;
+        abilityScoreIncrease[full] = value;
+        bonuses.push({ category: 'attributes', key: code, value: value, source: name });
+    });
+
+    const traits = [];
+    document.querySelectorAll('#raceTraitRows .subclass-feature-row').forEach(row => {
+        const traitName = row.querySelector('.race-trait-name').value.trim();
+        const traitDesc = row.querySelector('.race-trait-desc').value.trim();
+        if (!traitName && !traitDesc) return;
+        traits.push({ name: traitName, description: traitDesc });
+    });
+
+    const race = {
+        name: name,
+        year: document.getElementById('raceFormYear').value,
+        size: document.getElementById('raceFormSize').value,
+        speed: parseInt(document.getElementById('raceFormSpeed').value, 10) || 30,
+        languages: homebrewCsv('raceFormLanguages'),
+        abilityScoreIncrease: abilityScoreIncrease,
+        bonuses: bonuses,
+        traits: traits,
+        homebrew: true
+    };
+    const skills = homebrewCsv('raceFormSkills'); if (skills.length) race.skillProficiencies = skills;
+    const weapons = homebrewCsv('raceFormWeapons'); if (weapons.length) race.weaponProficiencies = weapons;
+    const armor = homebrewCsv('raceFormArmor'); if (armor.length) race.armorProficiencies = armor;
+    const tools = homebrewCsv('raceFormTools'); if (tools.length) race.toolProficiencies = tools;
+    const spells = homebrewCsv('raceFormSpells'); if (spells.length) race.spellsGranted = spells;
+    return race;
+}
+
+async function validateCustomRace(race) {
+    const errors = [];
+    const warnings = [];
+    if (!race.name) {
+        errors.push('The race needs a name.');
+    } else {
+        const index = await getBuiltInRaceIndex();
+        if (index.has(race.name.toLowerCase())) {
+            errors.push('A built-in race is already named "' + race.name + '". Pick a different name.');
+        }
+    }
+    if (!race.speed || race.speed <= 0) {
+        warnings.push('Walking speed is 0 - most races move 25-35 ft.');
+    }
+    if (Object.keys(race.abilityScoreIncrease || {}).length === 0) {
+        warnings.push('No ability score increase set - this race grants no ability bonuses.');
+    }
+    const spells = race.spellsGranted || [];
+    if (spells.length) {
+        const known = await getSpellNameIndex();
+        const unknown = spells.filter(s => !known.has(s.toLowerCase()));
+        if (unknown.length) warnings.push("These granted spells aren't in the catalog: " + unknown.join(', ') + '.');
+    }
+    return { errors: errors, warnings: warnings };
+}
+
+function loadAndDisplayCustomRaces() {
+    const select = document.getElementById('customRaceSelect');
+    if (!select) return;
+    loadDataFromGlobalStorage('Custom Races')
+        .then(races => {
+            select.innerHTML = '';
+            const names = Object.keys(races || {});
+            names.forEach(name => {
+                const option = document.createElement('option');
+                option.value = name;
+                option.textContent = name;
+                select.appendChild(option);
+            });
+            const empty = names.length === 0;
+            if (empty) {
+                const option = document.createElement('option');
+                option.value = '';
+                option.textContent = 'No races available';
+                select.appendChild(option);
+            }
+            select.disabled = empty;
+            document.getElementById('deleteCustomRaces').disabled = empty;
+        })
+        .catch(error => console.error('Failed to load custom races:', error));
+}
+
+const customRacesButton = document.getElementById('customRaces');
+if (customRacesButton) {
+    const raceFormModal = document.getElementById('raceFormModal');
+    customRacesButton.addEventListener('click', () => {
+        loadAndDisplayCustomRaces();
+        resetRaceForm();
+        raceFormModal.style.display = 'block';
+        homebrewModal.style.display = 'none';
+    });
+    document.getElementById('closeRaceForm').addEventListener('click', () => {
+        raceFormModal.style.display = 'none';
+    });
+    document.getElementById('raceFormName').addEventListener('input', clearRaceValidation);
+    document.getElementById('addRaceAbility').addEventListener('click', () => {
+        addHomebrewAbilityRow('raceAbilityRows', 'DEX', 2, clearRaceValidation);
+        clearRaceValidation();
+    });
+    document.getElementById('addRaceTrait').addEventListener('click', () => {
+        addRaceTraitRow();
+        clearRaceValidation();
+    });
+    document.getElementById('saveRace').addEventListener('click', async () => {
+        const saveButton = document.getElementById('saveRace');
+        const race = collectRaceFromForm();
+        const result = await validateCustomRace(race);
+        if (result.errors.length > 0) {
+            showHomebrewValidation('raceValidation', result.errors, result.warnings);
+            return;
+        }
+        if (result.warnings.length > 0 && saveButton.dataset.warningsConfirmed !== 'true') {
+            showHomebrewValidation('raceValidation', [], result.warnings);
+            saveButton.dataset.warningsConfirmed = 'true';
+            saveButton.textContent = 'Save Anyway';
+            return;
+        }
+        try {
+            await saveToGlobalStorage('Custom Races', race.name, race, false);
+        } catch (error) {
+            console.error('Failed to save custom race:', error);
+        }
+        raceFormModal.style.display = 'none';
+        loadAndDisplayCustomRaces();
+    });
+    document.getElementById('deleteCustomRaces').addEventListener('click', () => {
+        const selected = document.getElementById('customRaceSelect').value;
+        if (!selected) { errorModal('No race selected for deletion.'); return; }
+        removeFromGlobalStorage('Custom Races', selected)
+            .then(() => loadAndDisplayCustomRaces())
+            .catch(error => console.error('Failed to delete race:', error));
+    });
+    document.getElementById('editCustomRaces').addEventListener('click', () => {
+        const selected = document.getElementById('customRaceSelect').value;
+        if (!selected) { errorModal('No race selected for editing.'); return; }
+        loadDataFromGlobalStorage('Custom Races')
+            .then(races => {
+                const data = races[selected];
+                if (data) {
+                    raceFormModal.style.display = 'block';
+                    homebrewModal.style.display = 'none';
+                    populateRaceForm(data);
+                } else {
+                    errorModal('Race "' + selected + '" data not found.');
+                }
+            })
+            .catch(error => console.error('Failed to load race for editing:', error));
+    });
+    document.getElementById('exportCustomRace').addEventListener('click', () => {
+        exportData('Custom Races', document.getElementById('customRaceSelect').value);
+    });
+}
+
+const importCustomRaceButton = document.getElementById('importCustomRace');
+if (importCustomRaceButton && document.getElementById('importModal')) {
+    importCustomRaceButton.addEventListener('click', () => {
+        document.getElementById('importModal').style.display = 'flex';
+        document.getElementById('importTitle').textContent = 'Import Race Data';
+        document.getElementById('importTitle').setAttribute('data-type', 'Custom Races');
+    });
+}
+
+// ============================================================================
+// Custom feats
+// ============================================================================
+
+function clearFeatValidation() {
+    const box = document.getElementById('featValidation');
+    if (box) box.innerHTML = '';
+    const button = document.getElementById('saveFeat');
+    if (button) { button.dataset.warningsConfirmed = ''; button.textContent = 'Save Feat'; }
+}
+
+function resetFeatForm() {
+    document.getElementById('featFormTitle').textContent = 'Create a Feat';
+    document.getElementById('featFormName').value = '';
+    document.getElementById('featFormYear').selectedIndex = 0;
+    document.getElementById('featFormPrereq').value = '';
+    document.getElementById('featFormDesc').value = '';
+    document.getElementById('featFormMultiple').checked = false;
+    document.getElementById('featFormSpells').value = '';
+    document.getElementById('featFormProfs').value = '';
+    document.getElementById('featAbilityRows').innerHTML = '';
+    clearFeatValidation();
+}
+
+function populateFeatForm(feat) {
+    document.getElementById('featFormTitle').textContent = 'Edit Feat';
+    document.getElementById('featFormName').value = feat.name || '';
+    document.getElementById('featFormYear').value = feat.year === '2024' ? '2024' : '2014';
+    document.getElementById('featFormPrereq').value = feat.prerequisite || '';
+    document.getElementById('featFormDesc').value = (feat.description || []).join('\n');
+    document.getElementById('featFormMultiple').checked = !!feat.multiple;
+    document.getElementById('featFormSpells').value = (feat.spellsGranted || []).join(', ');
+    document.getElementById('featFormProfs').value = (feat.proficienciesGranted || []).join(', ');
+
+    const abilityRows = document.getElementById('featAbilityRows');
+    abilityRows.innerHTML = '';
+    (feat.abilityScoreIncrease || []).forEach(a =>
+        addHomebrewAbilityRow('featAbilityRows', a.ability, a.increase, clearFeatValidation));
+
+    clearFeatValidation();
+}
+
+function collectFeatFromForm() {
+    const name = document.getElementById('featFormName').value.trim();
+    const description = document.getElementById('featFormDesc').value
+        .split('\n').map(s => s.trim()).filter(Boolean);
+
+    const abilityScoreIncrease = [];
+    document.querySelectorAll('#featAbilityRows .homebrew-ability-row').forEach(row => {
+        const code = row.querySelector('.homebrew-ability-select').value;
+        const increase = parseInt(row.querySelector('.homebrew-ability-value').value, 10);
+        if (!code || !increase) return;
+        abilityScoreIncrease.push({ ability: code, increase: increase });
+    });
+
+    const feat = {
+        index: homebrewSlug(name),
+        name: name,
+        prerequisite: document.getElementById('featFormPrereq').value.trim(),
+        description: description,
+        bonus: [],
+        year: document.getElementById('featFormYear').value,
+        homebrew: true
+    };
+    if (abilityScoreIncrease.length) feat.abilityScoreIncrease = abilityScoreIncrease;
+    const spells = homebrewCsv('featFormSpells'); if (spells.length) feat.spellsGranted = spells;
+    const profs = homebrewCsv('featFormProfs'); if (profs.length) feat.proficienciesGranted = profs;
+    if (document.getElementById('featFormMultiple').checked) feat.multiple = true;
+    return feat;
+}
+
+async function validateCustomFeat(feat) {
+    const errors = [];
+    const warnings = [];
+    if (!feat.name) {
+        errors.push('The feat needs a name.');
+    } else {
+        const index = await getBuiltInFeatIndex();
+        if (index.has(feat.name.toLowerCase())) {
+            errors.push('A built-in feat is already named "' + feat.name + '". Pick a different name.');
+        }
+    }
+    if (!(feat.description || []).length) {
+        warnings.push('The feat has no description text.');
+    }
+    if ((feat.abilityScoreIncrease || []).length > 1) {
+        warnings.push('Several ability options are set - the builder will let the player pick one of them (half-feat style).');
+    }
+    const spells = feat.spellsGranted || [];
+    if (spells.length) {
+        const known = await getSpellNameIndex();
+        const unknown = spells.filter(s => !known.has(s.toLowerCase()));
+        if (unknown.length) warnings.push("These granted spells aren't in the catalog: " + unknown.join(', ') + '.');
+    }
+    return { errors: errors, warnings: warnings };
+}
+
+function loadAndDisplayCustomFeats() {
+    const select = document.getElementById('customFeatSelect');
+    if (!select) return;
+    loadDataFromGlobalStorage('Custom Feats')
+        .then(feats => {
+            select.innerHTML = '';
+            const names = Object.keys(feats || {});
+            names.forEach(name => {
+                const option = document.createElement('option');
+                option.value = name;
+                option.textContent = name;
+                select.appendChild(option);
+            });
+            const empty = names.length === 0;
+            if (empty) {
+                const option = document.createElement('option');
+                option.value = '';
+                option.textContent = 'No feats available';
+                select.appendChild(option);
+            }
+            select.disabled = empty;
+            document.getElementById('deleteCustomFeats').disabled = empty;
+        })
+        .catch(error => console.error('Failed to load custom feats:', error));
+}
+
+const customFeatsButton = document.getElementById('customFeats');
+if (customFeatsButton) {
+    const featFormModal = document.getElementById('featFormModal');
+    customFeatsButton.addEventListener('click', () => {
+        loadAndDisplayCustomFeats();
+        resetFeatForm();
+        featFormModal.style.display = 'block';
+        homebrewModal.style.display = 'none';
+    });
+    document.getElementById('closeFeatForm').addEventListener('click', () => {
+        featFormModal.style.display = 'none';
+    });
+    document.getElementById('featFormName').addEventListener('input', clearFeatValidation);
+    ['featFormPrereq', 'featFormDesc', 'featFormSpells', 'featFormProfs'].forEach(id =>
+        document.getElementById(id).addEventListener('input', clearFeatValidation));
+    document.getElementById('featFormMultiple').addEventListener('change', clearFeatValidation);
+    document.getElementById('addFeatAbility').addEventListener('click', () => {
+        addHomebrewAbilityRow('featAbilityRows', 'STR', 1, clearFeatValidation);
+        clearFeatValidation();
+    });
+    document.getElementById('saveFeat').addEventListener('click', async () => {
+        const saveButton = document.getElementById('saveFeat');
+        const feat = collectFeatFromForm();
+        const result = await validateCustomFeat(feat);
+        if (result.errors.length > 0) {
+            showHomebrewValidation('featValidation', result.errors, result.warnings);
+            return;
+        }
+        if (result.warnings.length > 0 && saveButton.dataset.warningsConfirmed !== 'true') {
+            showHomebrewValidation('featValidation', [], result.warnings);
+            saveButton.dataset.warningsConfirmed = 'true';
+            saveButton.textContent = 'Save Anyway';
+            return;
+        }
+        try {
+            await saveToGlobalStorage('Custom Feats', feat.name, feat, false);
+        } catch (error) {
+            console.error('Failed to save custom feat:', error);
+        }
+        featFormModal.style.display = 'none';
+        loadAndDisplayCustomFeats();
+    });
+    document.getElementById('deleteCustomFeats').addEventListener('click', () => {
+        const selected = document.getElementById('customFeatSelect').value;
+        if (!selected) { errorModal('No feat selected for deletion.'); return; }
+        removeFromGlobalStorage('Custom Feats', selected)
+            .then(() => loadAndDisplayCustomFeats())
+            .catch(error => console.error('Failed to delete feat:', error));
+    });
+    document.getElementById('editCustomFeats').addEventListener('click', () => {
+        const selected = document.getElementById('customFeatSelect').value;
+        if (!selected) { errorModal('No feat selected for editing.'); return; }
+        loadDataFromGlobalStorage('Custom Feats')
+            .then(feats => {
+                const data = feats[selected];
+                if (data) {
+                    featFormModal.style.display = 'block';
+                    homebrewModal.style.display = 'none';
+                    populateFeatForm(data);
+                } else {
+                    errorModal('Feat "' + selected + '" data not found.');
+                }
+            })
+            .catch(error => console.error('Failed to load feat for editing:', error));
+    });
+    document.getElementById('exportCustomFeat').addEventListener('click', () => {
+        exportData('Custom Feats', document.getElementById('customFeatSelect').value);
+    });
+}
+
+const importCustomFeatButton = document.getElementById('importCustomFeat');
+if (importCustomFeatButton && document.getElementById('importModal')) {
+    importCustomFeatButton.addEventListener('click', () => {
+        document.getElementById('importModal').style.display = 'flex';
+        document.getElementById('importTitle').textContent = 'Import Feat Data';
+        document.getElementById('importTitle').setAttribute('data-type', 'Custom Feats');
     });
 }
 

--- a/docs/README_HOMEBREW_AND_IMPORTS.md
+++ b/docs/README_HOMEBREW_AND_IMPORTS.md
@@ -10,6 +10,8 @@ Common content types include:
 - Characters
 - Custom spells
 - Custom subclasses
+- Custom races
+- Custom feats
 - Custom items
 - Custom monsters
 - Custom shops
@@ -22,6 +24,8 @@ Use the `Homebrew` button to manage:
 - Monsters
 - Spells
 - Subclasses
+- Races
+- Feats
 - Items
 - Shops
 
@@ -30,6 +34,8 @@ Use the `Homebrew` button to manage:
 Use the `Homebrew` button to manage:
 - Spells
 - Subclasses
+- Races
+- Feats
 - Items
 - Character data
 
@@ -73,6 +79,33 @@ Subclasses can also grant spells:
 Spell names are verified against the 5e and 5.5e catalogs plus your Custom Spells; unknown names produce a warning, and prepared-list grant levels are checked against the official domain/circle/oath patterns.
 
 Saved subclasses appear in the Character Creator as selectable subclasses for their class, filtered by the D&D Version setting the same way spells are. Import and export work like spells: export copies the subclass JSON to the clipboard, import accepts that same JSON. (Custom base classes are planned to follow the same storage pattern in the future.)
+
+### Custom Races
+
+Custom races can be created from the Homebrew menu on both the DM Screen and the Player Sheet. Each race records:
+- The edition it targets: 5e (2014) or 5.5e (2024)
+- Size and walking speed
+- Ability score increases (each row is a fixed bonus such as +2 Dexterity, +1 Wisdom)
+- Languages
+- Traits, each with a name and description
+- Skill, weapon, armor, and tool proficiencies
+- Spells granted (verified against the 5e/5.5e catalogs plus your Custom Spells)
+
+The form blocks names that collide with a built-in or DM-provided race and warns on things like a 0 speed, no ability increase, or an unknown granted spell (you can still save anyway for intentional homebrew). Saved races appear in the Character Creator's Species step, filtered by the D&D Version setting.
+
+### Custom Feats
+
+Custom feats can be created from the Homebrew menu on both the DM Screen and the Player Sheet. Each feat records:
+- The edition it targets: 5e (2014) or 5.5e (2024)
+- A prerequisite line (free text; leave blank for none)
+- A description (one paragraph per line; start a line with a bullet for a bullet point)
+- Ability score increase: add one ability for a fixed +N, or add several to let the player pick one of them (half-feat style — the Character Creator renders the picker automatically)
+- Spells granted and proficiencies granted
+- Whether the feat can be taken more than once
+
+The form blocks names that collide with a built-in or DM-provided feat and warns on an empty description or an unknown granted spell. Saved feats appear in the Character Creator's feat choice lists, filtered by the D&D Version setting.
+
+Both races and feats import and export like spells and subclasses: export copies the JSON to the clipboard, import accepts that same JSON.
 
 ### Custom Items
 

--- a/docs/README_LOCAL_CONTENT.md
+++ b/docs/README_LOCAL_CONTENT.md
@@ -1,0 +1,79 @@
+# Local Content (DM-provided, not committed)
+
+The symbiote can load extra spells, races, classes, and subclasses from an
+optional `local-content/` folder at the repo root. The folder is **gitignored**
+so licensed book content you own never lands in the public repository. To share
+it with your players, send them the folder directly (zip, Discord, private
+drive, etc.) and have them drop it into their copy of the symbiote:
+
+```
+TaleSpire/Symbiotes/TaleSpire-VTT/
+├── local-content/          <- gitignored, distributed out-of-band
+│   ├── spells.json
+│   ├── races.json
+│   ├── classes.json
+│   └── subclasses.json
+├── spells-eng.json
+└── CharacterCreator/
+```
+
+Every file is optional. A missing or invalid file is skipped silently (a
+warning is logged to the console) and the app runs on the shipped data alone.
+
+## How each file is merged
+
+| File | Shape | Merge rule |
+|---|---|---|
+| `spells.json` | Array of spell objects, same fields as `spells-eng.json` | Added to the catalog everywhere spells are listed (sheet, DM screen, creator). A local spell with the same **name + year** as a shipped spell replaces it. |
+| `races.json` | Object keyed by race key, same shape as `CharacterCreator/Races.json` | Merged into the creator's race list. Same key replaces the built-in race; new keys add races. |
+| `classes.json` | `{ "classes": { "<classKey>": {...} } }`, same shape as `CharacterCreator/Classes.json` | Same key replaces the whole built-in class; new keys add classes (e.g. `artificer`). |
+| `subclasses.json` | `{ "<classKey>": { "<Subclass Name>": {...} } }`, each entry shaped like a `Classes.json` subclass | Merged into that class's subclass list and its level-up choice dropdowns. Same name replaces the built-in (useful for completing trimmed entries). |
+
+Notes that apply across files:
+
+- **Edition filtering.** Spells and subclasses honor the D&DVersion setting via
+  an optional `"year"` field (`"2014"` or `"2024"`, default `"2014"`). Entries
+  tagged `"2024"` are hidden when the campaign is set to 2014 rules and vice
+  versa; `both` shows everything (2024 entries get the 🜁 suffix, same as the
+  shipped catalog).
+- **Local vs. homebrew.** Content here behaves like *built-in* content: unlike
+  homebrew subclasses created in the sheet's Homebrew tab, local subclasses may
+  replace built-ins, and the homebrew name-collision check treats local names
+  as reserved.
+- **Restart required.** Files are read when a page loads; reopen the symbiote
+  after editing them.
+
+## Authoring tips
+
+The starter files in `local-content/` contain one worked example each — copy
+the shape and replace the content. The committed data files are the full
+schema reference:
+
+- **Spells** — copy any entry from `spells-eng.json`. Useful conventions:
+  `casting_time` uses `1A` / `1BA` / `1R` / `1m` / `1Hr`; `level` is
+  `Cantrip` or `1st-level` … `9th-level`; `toHitOrDC` is `toHit`, `DC`, or
+  empty. Auto-granted subclass spells are driven by tags **on the spell
+  entry**: `domains` (cleric), `oaths` (paladin), `circles` (druid) make the
+  spell always-prepared for matching subclasses, and `patrons` (warlock)
+  expands the matching patron's options list. So when adding a subclass with
+  a spell list, either tag the spells here, or put a `subclassSpells` block on
+  the subclass (below).
+- **Races** — copy an entry from `CharacterCreator/Races.json`. The `bonuses`
+  array (category `attributes`, key `STR`/`DEX`/…) is what actually applies
+  the ability score increase; `abilityScoreIncrease` is display data. Keep
+  both in sync. `subraces` is optional.
+- **Classes** — copy a class from `CharacterCreator/Classes.json`. This is the
+  biggest schema (level progression, choices, spellcasting tables, starting
+  equipment — item names must match `equipment-eng.json` exactly).
+- **Subclasses** — copy a subclass from any class in
+  `CharacterCreator/Classes.json`, e.g. cleric → `Life` for a domain with
+  `domainSpells`, or fighter → `Eldritch Knight` for a third-caster
+  `spellcasting` block. A homebrew-style
+  `subclassSpells: { "mode": "prepared"|"expanded", "byLevel": { "3": ["Spell"] } }`
+  block also works if you'd rather not tag catalog spells.
+
+## Publishing checklist
+
+`local-content/` is listed in `.gitignore`, so `git status` should never show
+it. Before pushing the public repo, `git status --ignored` is a quick way to
+confirm the folder is being ignored rather than tracked.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Talespire 5e Toolset",
   "summary": "A VTT like experience for Talespire",
   "descriptionFilePath": "/README.md",
-  "version": "0.8.0.0",
+  "version": "0.9.8.0",
   "license": "MIT",
   "about": {
     "website": "",

--- a/styleShared.css
+++ b/styleShared.css
@@ -525,14 +525,19 @@ margin: 2px;
 /* The container that holds the modal content */
 .homebrew-modal-background {
     background-color: rgb(2, 2, 2);
-    margin: 5% auto; /* Center the modal */
+    margin: 3% auto; /* Center the modal */
     padding: 10px;
     border: 1px solid var(--border-outline-color);
     width: 90%; /* Adjust the width as needed */
+    max-width: 1000px; /* keep it compact on wide monitors */
     border-radius: 5px;
     z-index: 9;
     position: relative;
-    height: 90%;
+    height: auto; /* size to content instead of always filling 90% */
+    max-height: 94%; /* but never exceed the viewport */
+    box-sizing: border-box; /* keep padding inside the height cap */
+    overflow-y: auto; /* scroll tall content instead of running off-screen */
+    font-size: 0.9rem; /* shrink the whole creator a touch */
 }
 
 /* Center the modal content */
@@ -540,13 +545,20 @@ margin: 2px;
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-bottom: 10px;
+    margin-bottom: 8px;
+    font-size: 1.4rem;
 }
 
 #homebrewModalSubsectionStorage{
     display: grid;
-    grid-template-rows: 1fr 1fr;
-    gap: 5%;
+    grid-template-columns: 1fr 1fr; /* the two storage bars sit side by side */
+    gap: 6px 16px;
+    align-items: start;
+}
+
+/* The editor holds every create/delete row; span it under both storage bars */
+#homebrewModalSubsectionEditor{
+    grid-column: 1 / -1;
 }
 
 
@@ -574,12 +586,17 @@ margin: 2px;
 .deleteMonster {
     border: 1px solid var(--border-outline-color);
     border-radius: 5px;
-    padding: 10px;
+    padding: 6px;
 }
 
 .deleteMonster-header {
-    gap: 10px; 
-    margin-bottom: 5px; 
+    gap: 10px;
+    margin-bottom: 4px;
+}
+
+/* Tighten the dividers between each create/delete row */
+#homebrewModalSubsectionEditor hr {
+    margin: 6px 0;
 }
 
 #customMonsterSelect, #customShopSelect {
@@ -1400,6 +1417,84 @@ margin: 2px;
     margin: 5px 0;
 }
 
+/* Homebrew race & feat form modals (mirror the subclass form) */
+#raceFormModal,
+#featFormModal {
+    display: none;
+    position: fixed;
+    z-index: 9;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+}
+
+#raceForm,
+#featForm {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+#raceFormModal button,
+#featFormModal button {
+    margin-top: 10px;
+}
+
+.homebrew-subhead {
+    font-weight: bold;
+    margin: 10px 0 2px;
+    color: var(--button-color-hover);
+}
+
+.homebrew-hint {
+    font-style: italic;
+    opacity: 0.8;
+    margin: 0 0 6px;
+    font-size: 0.9em;
+}
+
+.homebrew-ability-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 6px;
+}
+
+.homebrew-ability-row .homebrew-ability-select {
+    flex: 1;
+}
+
+.homebrew-ability-plus {
+    opacity: 0.8;
+}
+
+.homebrew-ability-value {
+    width: 60px;
+    flex: 0 0 60px;
+}
+
+.homebrew-ability-row input,
+.homebrew-ability-row select {
+    background-color: rgb(2, 2, 2);
+    border: 1px solid var(--border-outline-color);
+    padding: 5px;
+    border-radius: 5px;
+    color: white;
+}
+
+.homebrew-ability-row .subclass-feature-remove {
+    margin-top: 0 !important;
+}
+
+.race-trait-name {
+    flex: 1;
+}
+
 .subclass-feature-row {
     border: 1px solid var(--border-outline-color);
     border-radius: 5px;
@@ -1640,11 +1735,22 @@ margin: 2px;
     display: none;
 }
 /* Give to Player (DM homebrew menu) */
+/* Only one child here, so override the 1fr/6fr grid and let it fill the row */
+#giveToPlayerSection {
+    grid-template-columns: 1fr;
+}
+
 .give-row {
     display: flex;
     gap: 6px;
     margin-top: 6px;
     align-items: center;
+}
+
+/* Positioned wrapper so the custom autocomplete dropdown anchors to the input */
+.give-input-wrap {
+    position: relative;
+    flex: 1;
 }
 
 .give-row input {
@@ -1654,6 +1760,24 @@ margin: 2px;
     border-radius: 5px;
     color: white;
     padding: 5px;
+}
+
+.give-input-wrap input {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.give-input-wrap .dropdown {
+    width: 100%;
+    margin-top: 3px;
+    padding-block: 4px; /* a little breathing room above/below the items */
+    max-height: 260px;
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.55); /* lift the list off the panel */
+}
+
+.give-input-wrap .dropdown-item {
+    border-radius: 4px;
+    margin: 0 4px;
 }
 
 .give-row button {


### PR DESCRIPTION
DM Screen homebrew panel:
- Fit the panel on 1080p monitors: size to content with a max-height/scroll safety net, cap the width, put the two storage bars side by side, and tighten spacing so the give-to-player section no longer runs off the bottom of the screen.
- The give-to-player picker now lists homebrew items and spells. Custom spells were being dropped by the D&DVersion edition filter, which now applies to the official/local catalogs only; homebrew always shows. The item/spell fields use the hand-rolled dropdown pattern (the TaleSpire webview doesn't render native <datalist> popups).
- The give autocomplete expands the panel to fit the open list (and scrolls it into view when the panel is capped) instead of spilling off-screen.

Monster creator + sheet:
- Add a Bonus Actions section, mirroring the existing Actions/Reactions handling: form fieldset, save/load, sheet rendering, and en/es translations.

Also bundles in-progress character-creator/homebrew work that was already in the working tree (CharacterCreator/*, PlayerScript, PlayerCharacter, local-content docs, manifest, etc.).